### PR TITLE
Fix icon alignment in macOS notification bar

### DIFF
--- a/GalaxyBudsClient/App.axaml
+++ b/GalaxyBudsClient/App.axaml
@@ -49,7 +49,9 @@
                       Icon="{OnPlatform '/Resources/icon_white_outlined_multi_tray.ico', Windows='/Resources/icon_white_outlined_single_tray.ico', macOS='/Resources/icon_black_tray.ico'}"
                       MacOSProperties.IsTemplateIcon="true"
                       ToolTipText="Galaxy Buds"
-                      Clicked="TrayIcon_OnClicked" />
+                      Clicked="TrayIcon_OnClicked"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center" />
         </TrayIcons>
     </TrayIcon.Icons>
 </Application>


### PR DESCRIPTION
Update the macOS notification bar icon alignment in `GalaxyBudsClient/App.axaml`.

* Add `HorizontalAlignment="Center"` and `VerticalAlignment="Center"` to the `TrayIcon` definition for macOS.
* Ensure the `Icon` property for macOS is set to `'/Resources/icon_black_tray.ico'`.