### PR TITLE
Bug fix for #519

### DIFF
--- a/GalaxyBudsClient/Utils/Interface/WindowIconRenderer.cs
+++ b/GalaxyBudsClient/Utils/Interface/WindowIconRenderer.cs
@@ -37,7 +37,7 @@ public static class WindowIconRenderer
 
         int? level = Settings.Data.DynamicTrayIconMode switch
         {
-            DynamicTrayIconModes.BatteryMin => Math.Min(batteryLeft, batteryLeft),
+            DynamicTrayIconModes.BatteryMin => Math.Min(batteryLeft, batteryRight),
             DynamicTrayIconModes.BatteryAvg => (batteryLeft + batteryRight) / 2,
             _ => null
         };


### PR DESCRIPTION
Fixes bug where icon doesn't show the proper battery level for the right bud if "show lowest battery level" is selected