### PR TITLE
Feature: Earbud color override

### DIFF
--- a/GalaxyBudsClient/Interface/Controls/EarbudIcon.cs
+++ b/GalaxyBudsClient/Interface/Controls/EarbudIcon.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.IO;
 using Avalonia;
@@ -30,6 +30,7 @@ public class EarbudIcon : Image
         BluetoothImpl.Instance.Connected += OnConnected;
         Settings.MainSettingsPropertyChanged += OnMainSettingsPropertyChanged;
         Settings.DevicePropertyChanged += OnDevicePropertyChanged;
+        Settings.Data.PropertyChanged += OnSettingsDataPropertyChanged;
         UpdateEarbudIcons();
     }
 
@@ -76,9 +77,15 @@ public class EarbudIcon : Image
         });
     }
 
+    private void OnSettingsDataPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(Settings.Data.ColorOverride))
+            UpdateEarbudIcons();
+    }
+
     private void UpdateEarbudIcons()
     {
-        var color = BluetoothImpl.Instance.Device.Current?.DeviceColor ?? DeviceMessageCache.Instance.ExtendedStatusUpdate?.DeviceColor;
+        var color = Settings.Data.ColorOverride ?? BluetoothImpl.Instance.Device.Current?.DeviceColor ?? DeviceMessageCache.Instance.ExtendedStatusUpdate?.DeviceColor;
         if (Settings.Data.RealisticEarbudImages && color != null &&
             BluetoothImpl.Instance.DeviceSpec.Supports(Features.DeviceColor))
         {

--- a/GalaxyBudsClient/Interface/MarkupExtensions/DeviceColorBindingSource.cs
+++ b/GalaxyBudsClient/Interface/MarkupExtensions/DeviceColorBindingSource.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Markup.Xaml;
+using GalaxyBudsClient.Model.Constants;
+using GalaxyBudsClient.Message;
+using GalaxyBudsClient.Platform;
+using System.Reflection;
+using GalaxyBudsClient.Model.Attributes;
+using GalaxyBudsClient.Model.Config;
+
+namespace GalaxyBudsClient.Interface.MarkupExtensions;
+
+public class DeviceColorBindingSource : MarkupExtension
+{
+    public override object ProvideValue(IServiceProvider serviceProvider)
+    {
+        var currentDevice = BluetoothImpl.Instance.Device.Current;
+        if (currentDevice == null)
+            return Array.Empty<DeviceIds>();
+
+        // Get current device's model and color
+        var currentModel = currentDevice.Model;
+        var currentColor = currentDevice.DeviceColor ?? 
+                         DeviceMessageCache.Instance.ExtendedStatusUpdate?.DeviceColor ?? 
+                         DeviceIds.Unknown;
+
+        // Get all colors for the current model using the AssociatedModel attribute
+        var values = Enum.GetValues(typeof(DeviceIds))
+            .Cast<DeviceIds>()
+            .Where(x => {
+                var field = typeof(DeviceIds).GetField(x.ToString());
+                var attr = field?.GetCustomAttribute<AssociatedModelAttribute>();
+                return attr != null && attr.Model == currentModel;
+            })
+            .OrderBy(x => x.ToString())
+            .ToList();
+
+        // Move current color to top if it exists in the list
+        if (currentColor != DeviceIds.Unknown && values.Contains(currentColor))
+        {
+            values.Remove(currentColor);
+            values.Insert(0, currentColor);
+        }
+
+        // Set the initial value if no override is set
+        if (Settings.Data.ColorOverride == null)
+        {
+            Settings.Data.ColorOverride = currentColor;
+        }
+        
+        return values;
+    }
+}

--- a/GalaxyBudsClient/Interface/MarkupExtensions/DeviceColorBindingSource.cs
+++ b/GalaxyBudsClient/Interface/MarkupExtensions/DeviceColorBindingSource.cs
@@ -25,7 +25,7 @@ public class DeviceColorBindingSource : MarkupExtension
                          DeviceMessageCache.Instance.ExtendedStatusUpdate?.DeviceColor ?? 
                          DeviceIds.Unknown;
 
-        // Get all colors for the current model using the AssociatedModel attribute
+        // Filter DeviceIds based on current model
         var values = Enum.GetValues(typeof(DeviceIds))
             .Cast<DeviceIds>()
             .Where(x => {

--- a/GalaxyBudsClient/Interface/Pages/SettingsPage.axaml
+++ b/GalaxyBudsClient/Interface/Pages/SettingsPage.axaml
@@ -107,6 +107,7 @@
                                                Content="{ext:Translate {x:Static i18N:Keys.SettingsColorOverride}}"
                                                Description="{ext:Translate {x:Static i18N:Keys.SettingsColorOverrideDescription}}"
                                                Symbol="ColorFill"
+                                               IsEnabled="{Binding RealisticEarbudImages, Source={x:Static config:Settings.Data}}"
                                                ItemsSource="{Binding ., Source={ext:DeviceColorBindingSource}}"
                                                SelectedValue="{Binding ColorOverride, Source={x:Static config:Settings.Data}}" />
 

--- a/GalaxyBudsClient/Interface/Pages/SettingsPage.axaml
+++ b/GalaxyBudsClient/Interface/Pages/SettingsPage.axaml
@@ -76,7 +76,7 @@
                         <ext:LocalizationAwareComboBoxBehavior />
                     </Interaction.Behaviors>
                 </controls:SettingsComboBoxItem>
-                
+
                 <controls:SettingsSliderItem
                     Content="{ext:Translate {x:Static i18N:Keys.SettingsBlurstrength}}"
                     Description="{ext:Translate {x:Static i18N:Keys.SettingsBlurstrengthDescription}}"
@@ -102,6 +102,13 @@
                                                Symbol="LocalLanguage"
                                                ItemsSource="{Binding Source={ext:LocalesBindingSource}}"
                                                SelectedValue="{Binding Locale, Source={x:Static config:Settings.Data}}" />
+                
+                <controls:SettingsComboBoxItem Name="ColorOverride"
+                                               Content="{ext:Translate {x:Static i18N:Keys.SettingsColorOverride}}"
+                                               Description="{ext:Translate {x:Static i18N:Keys.SettingsColorOverrideDescription}}"
+                                               Symbol="ColorFill"
+                                               ItemsSource="{Binding ., Source={ext:DeviceColorBindingSource}}"
+                                               SelectedValue="{Binding ColorOverride, Source={x:Static config:Settings.Data}}" />
 
                 <controls:SettingsSwitchItem Content="{ext:Translate {x:Static i18N:Keys.SettingsRealisticEarbudIcons}}"
                                              Description="{ext:Translate {x:Static i18N:Keys.SettingsRealisticEarbudIconsDescription}}"

--- a/GalaxyBudsClient/Model/Config/SettingsData.cs
+++ b/GalaxyBudsClient/Model/Config/SettingsData.cs
@@ -36,6 +36,7 @@ public class SettingsData : ReactiveObject
     [Reactive] public TemperatureUnits TemperatureUnit { set; get; } = TemperatureUnits.Celsius;
     [Reactive] public bool RealisticEarbudImages { set; get; } = true;
     [Reactive] public bool ShowSidebar { set; get; } = Settings.DefaultShowSidebar;
+    [Reactive] public DeviceIds? ColorOverride { set; get; }
     
     /* Connections */
     [Reactive] public bool UseBluetoothWinRt { set; get; } = true;

--- a/GalaxyBudsClient/i18n/en.axaml
+++ b/GalaxyBudsClient/i18n/en.axaml
@@ -427,6 +427,8 @@ Measure level: Select a vertical span to measure the battery level difference be
     <sys:String x:Key="settings_minimize_tray_description">Keep in background instead of terminating the app</sys:String>
     <sys:String x:Key="settings_realistic_earbud_icons">Use realistic earbud images</sys:String>
     <sys:String x:Key="settings_realistic_earbud_icons_description">Display realistic &amp; color-aware images of your earbuds, if they support it</sys:String>
+    <sys:String x:Key="settings_color_override">Earbud color override</sys:String>
+    <sys:String x:Key="settings_color_override_description">Change the displayed color of your earbuds in the app</sys:String>
     <sys:String x:Key="settings_nav_sidebar">Navigation sidebar</sys:String>
     <sys:String x:Key="settings_nav_sidebar_description">Show or collapse the navigation buttons on the left hand side</sys:String>
     <sys:String x:Key="settings_tray_settings">Tray icon &amp; startup</sys:String>

--- a/GalaxyBudsClient/i18n/tr.axaml
+++ b/GalaxyBudsClient/i18n/tr.axaml
@@ -375,6 +375,8 @@ Bittiğinde, toplanan tüm veriler için bir dizin seçmeniz istenecektir.
     <sys:String x:Key="settings_accent">Vurgu rengi</sys:String>
     <sys:String x:Key="settings_realistic_earbud_icons">Kulaklıkların gerçekçi resimlerini kullan</sys:String>
     <sys:String x:Key="settings_realistic_earbud_icons_description">Destekliyorsa, kulaklıklarınızın gerçekçi ve renk uyumlu resimlerini görüntüler</sys:String>
+    <sys:String x:Key="settings_color_override">Kulaklık resminin rengi</sys:String>
+    <sys:String x:Key="settings_color_override_description">Kulaklıklarınızın uygulamada görünen rengini değiştirin.</sys:String>
     <sys:String x:Key="settings_accent_description">Özel bir vurgu rengi seçin</sys:String>
     <sys:String x:Key="settings_transitions_description">Kaydırma geçişlerini etkinleştir</sys:String>
     <sys:String x:Key="settings_localization_disable">Dil</sys:String>


### PR DESCRIPTION
Adds a combo box in the settings page under "Appearance" that lists the possible colors for the user to choose from, and overrides the earbud images with the color selected.

Closes #579 