### PR TITLE
added styles to fix title bar control colors

### DIFF
--- a/GalaxyBudsClient/App.axaml
+++ b/GalaxyBudsClient/App.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:styling="clr-namespace:FluentAvalonia.Styling;assembly=FluentAvalonia"
              xmlns:galaxyBudsClient="clr-namespace:GalaxyBudsClient"
+             xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
              x:Class="GalaxyBudsClient.App"
              Name="Galaxy Buds Manager">
 
@@ -25,6 +26,7 @@
                 <!-- Resources -->
                 <ResourceInclude Source="/Interface/Styling/Resources.axaml" />
             </ResourceDictionary.MergedDictionaries>
+            <Color x:Key="AccentColor">Orange</Color>
         </ResourceDictionary>
     </Application.Resources>
 
@@ -42,6 +44,26 @@
                 <StyleInclude Source="/Interface/Styling/Overrides/OsxOverrides.axaml" />
             </OnPlatform.macOS>
         </OnPlatform>
+        
+        <Style Selector="Button#CloseButton:inactive:not(:pointerover) controls|FontIcon">
+            <Setter Property="Foreground" Value="{DynamicResource AccentColor}" />
+        </Style>
+
+        <Style Selector="Button#MinimizeButton:pointerover Border">
+            <Setter Property="Background" Value="{DynamicResource AccentColor}" />
+        </Style>
+        
+        <Style Selector="Button#MinimizeButton:inactive:not(:pointerover) controls|FontIcon">
+            <Setter Property="Foreground" Value="{DynamicResource AccentColor}" />
+        </Style>
+        
+        <Style Selector="Button#MaxRestoreButton:pointerover Border">
+            <Setter Property="Background" Value="{DynamicResource AccentColor}" />
+        </Style>
+        
+        <Style Selector="Button#MaxRestoreButton:inactive:not(:pointerover) controls|FontIcon">
+            <Setter Property="Foreground" Value="{DynamicResource AccentColor}" />
+        </Style>
     </Application.Styles>
     <TrayIcon.Icons>
         <TrayIcons>

--- a/GalaxyBudsClient/App.axaml.cs
+++ b/GalaxyBudsClient/App.axaml.cs
@@ -95,7 +95,7 @@ public class App : Application
         Log.Debug("Environment: {Env}", _experimentManager.CurrentEnvironment());
 #endif
     }
-
+    
     public override void OnFrameworkInitializationCompleted()
     {
         if (BluetoothImpl.HasValidDevice)
@@ -262,6 +262,7 @@ public class App : Application
             color = Settings.Data.AccentColor = Colors.Orange.ToUInt32();
         }
         FluentTheme.CustomAccentColor = Color.FromUInt32(color);
+        Resources["AccentColor"] = FluentTheme.CustomAccentColor;
     }
         
     private void TrayIcon_OnClicked(object? sender, EventArgs e)


### PR DESCRIPTION
Added Styles to fix title bar color overlay.
ISSUE #578 

---- Fix
**Inactive looks**
![image](https://github.com/user-attachments/assets/7e403282-6c10-4348-a544-20e0f7b26687)

**Hover looks**
![image](https://github.com/user-attachments/assets/4cf8bacf-8951-4bb7-864c-4298a9adc730)
![image](https://github.com/user-attachments/assets/4f37e783-3571-4072-ba21-c4159b120d87)

----- Notes
- I tried to create direct Binding to FluentTheme.CustomAccentColor or the Settings.CustomAccentColor, But I was not able to. It didn't work unfortunately.  So, I had to create a resource.
- I think this is an issue or a bug related to FluentTheme. In the code, the titleBarOverlay colors is set from the accent color, however for some reason, the accent color doesn't reflect the customAccentColor. [Reference](https://github.com/amwx/FluentAvalonia/blob/v2.0.4/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs#L353).
- Lastly, this was not tested either on Mac or Linux, so no idea how they will look.