### PR TITLE
fix(osx): prevent bluetooth connect crashes from missing device metadata.

### DIFF
--- a/GalaxyBudsClient.Platform.OSX/BluetoothService.cs
+++ b/GalaxyBudsClient.Platform.OSX/BluetoothService.cs
@@ -87,6 +87,16 @@ namespace GalaxyBudsClient.Platform.OSX
             Console.WriteLine("OSX.BluetoothService: Channel closed. Disconnected.");
             Disconnected?.Invoke(this, "Device lost connection");
         }
+
+        private static string NativeUtf8ToString(IntPtr ptr)
+        {
+            return ptr == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUTF8(ptr) ?? string.Empty;
+        }
+
+        private static string NativeUtf8ToMacAddress(IntPtr ptr)
+        {
+            return NativeUtf8ToString(ptr).Replace("-", ":");
+        }
         
         public bool IsStreamConnected
         {
@@ -125,8 +135,8 @@ namespace GalaxyBudsClient.Platform.OSX
                         {
                             Device* d = &rawDevices[i];
                             devices[i] = new BluetoothDevice(
-                                Marshal.PtrToStringUTF8(d->device_name) ?? String.Empty,
-                                (Marshal.PtrToStringUTF8(d->mac_address) ?? String.Empty).Replace("-", ":"),
+                                NativeUtf8ToString(d->device_name),
+                                NativeUtf8ToMacAddress(d->mac_address),
                                 d->is_connected,
                                 d->is_paired,
                                 new BluetoothCoD(d->cod),
@@ -159,8 +169,7 @@ namespace GalaxyBudsClient.Platform.OSX
 
         private void OnDisconnected(IntPtr mac)
         {
-            var macAddr = Marshal.PtrToStringAnsi(mac) ?? string.Empty;
-            macAddr = macAddr.Replace("-", ":");
+            var macAddr = NativeUtf8ToMacAddress(mac);
             if (string.Equals(macAddr, _currentMac, StringComparison.CurrentCultureIgnoreCase))
             {
                 Disconnected?.Invoke(this, "Device was disconnected");
@@ -188,8 +197,7 @@ namespace GalaxyBudsClient.Platform.OSX
                     }
                 });
 
-                var macAddr = Marshal.PtrToStringAnsi(mac) ?? string.Empty;
-                macAddr = macAddr.Replace("-", ":");
+                var macAddr = NativeUtf8ToMacAddress(mac);
                 if (string.Equals(macAddr, _currentMac, StringComparison.CurrentCultureIgnoreCase))
                 {
                     Log.Debug("OSX.BluetoothService: Reconnecting to {MacAddr}", macAddr);

--- a/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
@@ -3,8 +3,67 @@
 // Copyright (c) 2021 Tim Schneeberger. Licensed under GPLv3.
 //
 
+#include <stdlib.h>
+#include <string.h>
+
 #import <IOBluetooth/IOBluetooth.h>
+
 #import "Bluetooth.h"
+
+static BOOL IsNullOrEmpty(NSString *value) {
+    return value == nil || [value length] == 0;
+}
+
+static NSString *FirstNonEmptyString(NSString *first, NSString *second, NSString *third) {
+    if (!IsNullOrEmpty(first)) {
+        return first;
+    }
+
+    if (!IsNullOrEmpty(second)) {
+        return second;
+    }
+
+    if (!IsNullOrEmpty(third)) {
+        return third;
+    }
+
+    return @"";
+}
+
+static char *CopyNSStringToUtf8CString(NSString *value) {
+    if (value == nil) {
+        return NULL;
+    }
+
+    const char *utf8String = [value UTF8String];
+    if (utf8String == NULL) {
+        return NULL;
+    }
+
+    size_t length = strlen(utf8String);
+    char *copy = (char *)malloc(length + 1);
+    if (copy == NULL) {
+        return NULL;
+    }
+
+    memcpy(copy, utf8String, length + 1);
+    return copy;
+}
+
+static void FreeEnumerationDevices(EnumerationResult *result, int initializedCount) {
+    if (result == NULL || result->devices == NULL) {
+        return;
+    }
+
+    for (int i = 0; i < initializedCount; i++) {
+        free(result->devices[i].mac_address);
+        free(result->devices[i].device_name);
+    }
+
+    free(result->devices);
+    result->devices = NULL;
+    result->length = 0;
+}
 
 @implementation Bluetooth {
     NSString *_macAddress;
@@ -155,22 +214,42 @@
 }
 
 - (BT_ENUM_RESULT)enumerate:(EnumerationResult *)result {
+    if (result == NULL) {
+        NSLog(@"Error - failed to enumerate - result pointer is null!");
+        return BT_ENUM_EUNKNOWN;
+    }
+
+    result->length = 0;
+    result->devices = NULL;
+
     NSArray *inDevices = [IOBluetoothDevice pairedDevices];
 
-    result->length = (int)(unsigned long)[inDevices count];
-    result->devices = (Device*)malloc(sizeof(Device) * result->length);
+    int deviceCount = (int)(unsigned long)[inDevices count];
+    if (deviceCount == 0) {
+        return BT_ENUM_SUCCESS;
+    }
+
+    result->devices = (Device*)calloc((size_t)deviceCount, sizeof(Device));
     if (!result->devices) {
         NSLog(@"Error - failed to enumerate - out of memory!");
         return BT_ENUM_EUNKNOWN;
     }
+    result->length = deviceCount;
 
     for (int i = 0; i < result->length; i++) {
         Device *resultDevice = &result->devices[i];
         IOBluetoothDevice *device = [inDevices objectAtIndex:i];
-        resultDevice->device_name = (char *)malloc([device.name lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        resultDevice->mac_address = (char *)malloc([device.addressString lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        strcpy(resultDevice->device_name, device.name.UTF8String);
-        strcpy(resultDevice->mac_address, device.addressString.UTF8String);
+        NSString *addressString = FirstNonEmptyString([device addressString], nil, nil);
+        NSString *nameString = FirstNonEmptyString([device name], [device nameOrAddress], addressString);
+
+        resultDevice->device_name = CopyNSStringToUtf8CString(nameString);
+        resultDevice->mac_address = CopyNSStringToUtf8CString(addressString);
+        if (resultDevice->device_name == NULL || resultDevice->mac_address == NULL) {
+            NSLog(@"Error - failed to enumerate - unable to copy device strings!");
+            FreeEnumerationDevices(result, i + 1);
+            return BT_ENUM_EUNKNOWN;
+        }
+
         resultDevice->is_connected = device.isConnected;
         resultDevice->is_paired = device.isPaired;
         resultDevice->cod = device.classOfDevice;

--- a/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
@@ -195,27 +195,34 @@ static void FreeEnumerationDevices(EnumerationResult *result, int initializedCou
         NSLog(@"Error - failed to enumerate - out of memory!");
         return BT_ENUM_EUNKNOWN;
     }
-    result->length = deviceCount;
 
-    for (int i = 0; i < result->length; i++) {
-        Device *resultDevice = &result->devices[i];
+    int validCount = 0;
+    for (int i = 0; i < deviceCount; i++) {
         IOBluetoothDevice *device = [inDevices objectAtIndex:i];
-        NSString *addressString = FirstNonEmptyString([device addressString], nil, nil);
+        NSString *addressString = [device addressString];
+        if (IsNullOrEmpty(addressString)) {
+            NSLog(@"Bluetooth::enumerate(): Skipping paired device with missing address: %@", device);
+            continue;
+        }
+
+        Device *resultDevice = &result->devices[validCount];
         NSString *nameString = FirstNonEmptyString([device name], [device nameOrAddress], addressString);
 
         resultDevice->device_name = CopyNSStringToUtf8CString(nameString);
         resultDevice->mac_address = CopyNSStringToUtf8CString(addressString);
         if (resultDevice->device_name == NULL || resultDevice->mac_address == NULL) {
             NSLog(@"Error - failed to enumerate - unable to copy device strings!");
-            FreeEnumerationDevices(result, i + 1);
+            FreeEnumerationDevices(result, validCount + 1);
             return BT_ENUM_EUNKNOWN;
         }
 
         resultDevice->is_connected = device.isConnected;
         resultDevice->is_paired = device.isPaired;
         resultDevice->cod = device.classOfDevice;
+        validCount++;
     }
 
+    result->length = validCount;
     return BT_ENUM_SUCCESS;
 }
 

--- a/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
@@ -9,46 +9,7 @@
 #import <IOBluetooth/IOBluetooth.h>
 
 #import "Bluetooth.h"
-
-static BOOL IsNullOrEmpty(NSString *value) {
-    return value == nil || [value length] == 0;
-}
-
-static NSString *FirstNonEmptyString(NSString *first, NSString *second, NSString *third) {
-    if (!IsNullOrEmpty(first)) {
-        return first;
-    }
-
-    if (!IsNullOrEmpty(second)) {
-        return second;
-    }
-
-    if (!IsNullOrEmpty(third)) {
-        return third;
-    }
-
-    return @"";
-}
-
-static char *CopyNSStringToUtf8CString(NSString *value) {
-    if (value == nil) {
-        return NULL;
-    }
-
-    const char *utf8String = [value UTF8String];
-    if (utf8String == NULL) {
-        return NULL;
-    }
-
-    size_t length = strlen(utf8String);
-    char *copy = (char *)malloc(length + 1);
-    if (copy == NULL) {
-        return NULL;
-    }
-
-    memcpy(copy, utf8String, length + 1);
-    return copy;
-}
+#import "NativeStringUtils.h"
 
 static void FreeEnumerationDevices(EnumerationResult *result, int initializedCount) {
     if (result == NULL || result->devices == NULL) {

--- a/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
@@ -3,11 +3,54 @@
 // Copyright (c) 2021 Tim Schneeberger. Licensed under GPLv3.
 //
 
+#include <stdlib.h>
+#include <string.h>
+
 #import <IOBluetooth/IOBluetooth.h>
+
 #import "Bluetooth.h"
 #import "BluetoothDeviceWatcher.h"
 #import "Native.h"
 
+static BOOL IsNullOrEmpty(NSString *value) {
+    return value == nil || [value length] == 0;
+}
+
+static NSString *FirstNonEmptyString(NSString *first, NSString *second, NSString *third) {
+    if (!IsNullOrEmpty(first)) {
+        return first;
+    }
+
+    if (!IsNullOrEmpty(second)) {
+        return second;
+    }
+
+    if (!IsNullOrEmpty(third)) {
+        return third;
+    }
+
+    return @"";
+}
+
+static char *CopyNSStringToUtf8CString(NSString *value) {
+    if (value == nil) {
+        return NULL;
+    }
+
+    const char *utf8String = [value UTF8String];
+    if (utf8String == NULL) {
+        return NULL;
+    }
+
+    size_t length = strlen(utf8String);
+    char *copy = (char *)malloc(length + 1);
+    if (copy == NULL) {
+        return NULL;
+    }
+
+    memcpy(copy, utf8String, length + 1);
+    return copy;
+}
 
 @implementation BluetoothDeviceWatcher {
     BtDev_OnConnected _onConnected;
@@ -45,18 +88,44 @@
 
 - (void)onConnected:(IOBluetoothUserNotification *)notification fromDevice:(IOBluetoothDevice *)device {
     if (_onConnected) {
-        char *mac = (char *)malloc([[device addressString] lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        char *name = (char *)malloc([[device nameOrAddress] lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        strcpy(mac, device.addressString.UTF8String);
-        strcpy(name, device.nameOrAddress.UTF8String);
+        NSString *addressString = [device addressString];
+        if (IsNullOrEmpty(addressString)) {
+            NSLog(@"BluetoothDeviceWatcher: Ignoring connect notification without device address: %@\n", device);
+            return;
+        }
+
+        char *mac = CopyNSStringToUtf8CString(addressString);
+        if (mac == NULL) {
+            NSLog(@"BluetoothDeviceWatcher: Failed to copy connect notification device address: %@\n", addressString);
+            return;
+        }
+
+        NSString *nameString = FirstNonEmptyString([device name], [device nameOrAddress], addressString);
+        char *name = CopyNSStringToUtf8CString(nameString);
+        if (name == NULL) {
+            NSLog(@"BluetoothDeviceWatcher: Failed to copy connect notification device name for %@\n", addressString);
+            free(mac);
+            return;
+        }
+
         _onConnected(mac, name);
     }
 }
 
 - (void)onDisconnected:(IOBluetoothUserNotification *)notification fromDevice:(IOBluetoothDevice *)device {
     if (_onDisconnected) {
-        char *mac = (char *)malloc([[device addressString] lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        strcpy(mac, device.addressString.UTF8String);
+        NSString *addressString = [device addressString];
+        if (IsNullOrEmpty(addressString)) {
+            NSLog(@"BluetoothDeviceWatcher: Ignoring disconnect notification without device address: %@\n", device);
+            return;
+        }
+
+        char *mac = CopyNSStringToUtf8CString(addressString);
+        if (mac == NULL) {
+            NSLog(@"BluetoothDeviceWatcher: Failed to copy disconnect notification device address: %@\n", addressString);
+            return;
+        }
+
         _onDisconnected(mac);
     }
 }

--- a/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
@@ -3,54 +3,12 @@
 // Copyright (c) 2021 Tim Schneeberger. Licensed under GPLv3.
 //
 
-#include <stdlib.h>
-#include <string.h>
-
 #import <IOBluetooth/IOBluetooth.h>
 
 #import "Bluetooth.h"
 #import "BluetoothDeviceWatcher.h"
 #import "Native.h"
-
-static BOOL IsNullOrEmpty(NSString *value) {
-    return value == nil || [value length] == 0;
-}
-
-static NSString *FirstNonEmptyString(NSString *first, NSString *second, NSString *third) {
-    if (!IsNullOrEmpty(first)) {
-        return first;
-    }
-
-    if (!IsNullOrEmpty(second)) {
-        return second;
-    }
-
-    if (!IsNullOrEmpty(third)) {
-        return third;
-    }
-
-    return @"";
-}
-
-static char *CopyNSStringToUtf8CString(NSString *value) {
-    if (value == nil) {
-        return NULL;
-    }
-
-    const char *utf8String = [value UTF8String];
-    if (utf8String == NULL) {
-        return NULL;
-    }
-
-    size_t length = strlen(utf8String);
-    char *copy = (char *)malloc(length + 1);
-    if (copy == NULL) {
-        return NULL;
-    }
-
-    memcpy(copy, utf8String, length + 1);
-    return copy;
-}
+#import "NativeStringUtils.h"
 
 @implementation BluetoothDeviceWatcher {
     BtDev_OnConnected _onConnected;

--- a/GalaxyBudsClient.Platform.OSX/Native/src/NativeStringUtils.h
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/NativeStringUtils.h
@@ -1,0 +1,50 @@
+//
+// Created by Tim Schneeberger. Licensed under GPLv3.
+//
+
+#pragma once
+
+#include <stdlib.h>
+#include <string.h>
+
+#import <Foundation/Foundation.h>
+
+static inline BOOL IsNullOrEmpty(NSString *value) {
+    return value == nil || [value length] == 0;
+}
+
+static inline NSString *FirstNonEmptyString(NSString *first, NSString *second, NSString *third) {
+    if (!IsNullOrEmpty(first)) {
+        return first;
+    }
+
+    if (!IsNullOrEmpty(second)) {
+        return second;
+    }
+
+    if (!IsNullOrEmpty(third)) {
+        return third;
+    }
+
+    return @"";
+}
+
+static inline char *CopyNSStringToUtf8CString(NSString *value) {
+    if (value == nil) {
+        return NULL;
+    }
+
+    const char *utf8String = [value UTF8String];
+    if (utf8String == NULL) {
+        return NULL;
+    }
+
+    size_t length = strlen(utf8String);
+    char *copy = (char *)malloc(length + 1);
+    if (copy == NULL) {
+        return NULL;
+    }
+
+    memcpy(copy, utf8String, length + 1);
+    return copy;
+}


### PR DESCRIPTION

## Summary

This fixes a macOS Bluetooth crash where connect or disconnect notifications can arrive without complete device metadata. The native watcher previously copied `NSString.UTF8String` values directly into C strings, which could dereference a null pointer before the managed callback was reached.

## Tasks

- Harden Bluetooth connect and disconnect watcher callbacks by validating the device address before invoking managed code.
- Add safe native UTF-8 string copying and name fallback handling for optional Bluetooth device names.
- Make paired-device enumeration resilient to missing native name or address strings and clean up partial allocations on failure.
- Add managed-side null pointer handling before converting native UTF-8 strings.

## Verification

- `git diff --check`.
- `xcodebuild -project GalaxyBudsClient.Platform.OSX/Native/NativeInterop.xcodeproj -scheme NativeInterop -destination platform=macOS build`.

## Not Run

- `dotnet restore --configfile GalaxyBudsClient/nuget.config GalaxyBudsClient/GalaxyBudsClient.csproj`: `dotnet` is not available in this shell.
- `dotnet build GalaxyBudsClient.sln -c Debug`: `dotnet` is not available in this shell.
- `dotnet test GalaxyBudsClient.Tests/GalaxyBudsClient.Tests.csproj -c Debug`: `dotnet` is not available in this shell.
- Manual Bluetooth connect/disconnect regression checks.

## Notes

There is no dedicated pull request template in `docs/` or `.github`; this draft follows the docs contribution guidance to explain the changes.
