### PR TITLE
Fix Buds3 Pro false positive model mismatch during firmware updates

### DIFF
--- a/GalaxyBudsClient/Message/Decoder/DebugSkuDecoder.cs
+++ b/GalaxyBudsClient/Message/Decoder/DebugSkuDecoder.cs
@@ -29,7 +29,7 @@ public class DebugSkuDecoder : BaseMessageDecoder
         if (build == null)
             return null;
             
-        foreach (var model in ModelsExtensions.GetValues())
+        foreach (var model in ModelsExtensions.GetValues().Reverse())
         {
             var pattern = model.GetModelMetadataAttribute()?.FwPattern;
             if(pattern == null)

--- a/GalaxyBudsClient/Model/Firmware/FirmwareBinary.cs
+++ b/GalaxyBudsClient/Model/Firmware/FirmwareBinary.cs
@@ -108,7 +108,7 @@ public class FirmwareBinary
     public static Models? DetectModel(ref readonly byte[] data)
     {
         var fastSearch = new BoyerMoore();
-        foreach (var model in ModelsExtensions.GetValues())
+        foreach (var model in ModelsExtensions.GetValues().Reverse())
         {
             if(model == Models.NULL)
                 continue;


### PR DESCRIPTION
Fixes #707

**Problem:**
When updating firmware on Galaxy Buds3 Pro, users get a false "Device model mismatch detected!" error. This happens because the firmware model detection iterates through the \"Models\" enum in declaration order, where Buds3 (SM-R530) comes before Buds3Pro (SM-R630). If a Buds3 Pro firmware binary contains both SKU strings, it incorrectly matches as Buds3 first.

**Fix:**
Added \".Reverse()\" to both model detection loops so newer/more specific models are checked first. This mirrors the existing fix in DeviceSpecHelper.cs where Pro models are explicitly registered before base models (see comments: \"important: B3Pro is added before B3 to avoid false positives\").

**Files changed:**
- GalaxyBudsClient/Model/Firmware/FirmwareBinary.cs
- GalaxyBudsClient/Message/Decoder/DebugSkuDecoder.cs

**Also protects against:**
- Buds2 / Buds2Pro same issue
- Buds4 / Buds4Pro same issue