### PR TITLE
Persist settings changes for devices/hotkeys loaded from disk

### DIFF
--- a/GalaxyBudsClient/Model/Config/Settings.cs
+++ b/GalaxyBudsClient/Model/Config/Settings.cs
@@ -38,6 +38,14 @@ public static class Settings
         Data.ExperimentsFinishedIds.CollectionChanged += (_, _) => Save();
         Data.CustomActionLeft.PropertyChanged += OnTouchActionPropertyChanged;
         Data.CustomActionRight.PropertyChanged += OnTouchActionPropertyChanged;
+
+        // CollectionChanged only fires for items added/removed after load, so devices and hotkeys
+        // deserialized from disk are never subscribed to their property-change handlers. Without
+        // this, changing a property on an already-saved device or hotkey does not trigger a Save().
+        foreach (var device in Data.Devices)
+            device.PropertyChanged += OnDevicePropertyChanged;
+        foreach (var hotkey in Data.Hotkeys)
+            hotkey.PropertyChanged += OnHotkeyPropertyChanged;
     }
     
     public static Themes DefaultTheme => PlatformUtils.SupportsMicaTheme ? Themes.DarkMica : 


### PR DESCRIPTION
## Problem

`Settings` only attaches a device's/hotkey's `PropertyChanged -> Save()` handler through the collection's `CollectionChanged` event (`OnDeviceCollectionChanged` / `OnHotkeyCollectionChanged`), which fires only for items **added or removed at runtime**. Devices and hotkeys deserialized from `settings.json` at startup are already present in their collections when those handlers are wired up, so they are never individually subscribed.

As a result, changing a property on an **already-saved** device or hotkey never triggers a save, and the change is lost on the next launch. (Root settings and touch actions are unaffected — they are subscribed directly.)

## Fix

Subscribe each loaded device and hotkey in the static constructor, mirroring what the `CollectionChanged` handlers already do for runtime-added items. Items added later are unaffected (loaded items are never re-added, so there is no double-subscription).

```csharp
foreach (var device in Data.Devices)
    device.PropertyChanged += OnDevicePropertyChanged;
foreach (var hotkey in Data.Hotkeys)
    hotkey.PropertyChanged += OnHotkeyPropertyChanged;
```

## Scope / risk

- One file, +8 lines.
- Platform- and device-agnostic; no behavior change for runtime-added items.
- Builds clean on `net10.0-macos`.
