### PR TITLE
Buds4 Pro: ambient volume 0-4, 9-band custom EQ, macOS native Bluetooth fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -456,3 +456,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# macOS publish output (installers/bundles)
+bin_osx*/

--- a/GalaxyBudsClient.Platform.OSX/BluetoothService.cs
+++ b/GalaxyBudsClient.Platform.OSX/BluetoothService.cs
@@ -12,6 +12,7 @@ namespace GalaxyBudsClient.Platform.OSX
     {
         private static readonly SemaphoreSlim ConnSemaphore = new(1, 1);
         private static readonly SemaphoreSlim SearchSemaphore = new(1, 1);
+        private static readonly SemaphoreSlim SendSemaphore = new(1, 1);
 
         private string _currentMac = string.Empty;
         private string _currentUuid = string.Empty;
@@ -323,12 +324,22 @@ namespace GalaxyBudsClient.Platform.OSX
         public async Task SendAsync(byte[] data)
         {
             BT_SEND_RESULT result;
-            unsafe
+            // Serialize sends: concurrent bt_send calls interleave their MTU-sized
+            // chunks in the RFCOMM stream, corrupting frame boundaries
+            await SendSemaphore.WaitAsync();
+            try
             {
-                fixed (byte* raw = data)
+                unsafe
                 {
-                    result = Bluetooth.bt_send(_nativePtr, raw, (uint)data.Length);
+                    fixed (byte* raw = data)
+                    {
+                        result = Bluetooth.bt_send(_nativePtr, raw, (uint)data.Length);
+                    }
                 }
+            }
+            finally
+            {
+                SendSemaphore.Release();
             }
 
             if (result != BT_SEND_RESULT.BT_SEND_SUCCESS)

--- a/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
@@ -93,7 +93,9 @@
     // Open the RFCOMM channel on the new device connection
     IOBluetoothRFCOMMChannel *tempRFCOMMChannel = mRFCOMMChannel;
     status = [device openRFCOMMChannelSync:&tempRFCOMMChannel withChannelID:rfcommChannelID delegate:self];
-    mRFCOMMChannel = tempRFCOMMChannel;
+    @synchronized (self) {
+        mRFCOMMChannel = tempRFCOMMChannel;
+    }
     
     if (mRFCOMMChannel == nil) {
         NSLog(@"Error: %s - unable to open RFCOMM channel.\n", mach_error_string(status) );
@@ -136,15 +138,21 @@
 
 - (BOOL)disconnect
 {
-    if (mRFCOMMChannel != nil) {
-        // This will close the RFCOMM channel and start an inactivity timer to close the baseband connection if no
-        // other channels (L2CAP or RFCOMM) are open.
-        [mRFCOMMChannel setDelegate:nil];
-        [mRFCOMMChannel closeChannel];
-        
+    // mRFCOMMChannel is also read by sendData on another thread; swap it out
+    // under the lock so in-flight sends keep a valid (closed) channel object.
+    IOBluetoothRFCOMMChannel *channel;
+    @synchronized (self) {
+        channel = mRFCOMMChannel;
         mRFCOMMChannel = nil;
     }
-    
+
+    if (channel != nil) {
+        // This will close the RFCOMM channel and start an inactivity timer to close the baseband connection if no
+        // other channels (L2CAP or RFCOMM) are open.
+        [channel setDelegate:nil];
+        [channel closeChannel];
+    }
+
     _macAddress = NULL;
 
     return TRUE;
@@ -183,8 +191,17 @@
 
 - (BT_SEND_RESULT)sendData:(char *)buffer length:(UInt32)length
 {
-    if (mRFCOMMChannel != nil) {
-        if (![mRFCOMMChannel isOpen]) {
+    // Snapshot the channel: the IOBluetooth callback thread can run disconnect
+    // (nilling mRFCOMMChannel) while this loop is mid-write. The local strong
+    // reference keeps the object alive; writeSync on a closed channel just
+    // returns an error and ends the loop.
+    IOBluetoothRFCOMMChannel *channel;
+    @synchronized (self) {
+        channel = mRFCOMMChannel;
+    }
+
+    if (channel != nil) {
+        if (![channel isOpen]) {
             [self disconnect];
             _onChannelClosed();
             return BT_SEND_ENULL;
@@ -198,16 +215,21 @@
 
         // Get the RFCOMM Channel's MTU.  Each write can only contain up to the MTU size
         // number of bytes.
-        rfcommChannelMTU = [mRFCOMMChannel getMTU];
+        rfcommChannelMTU = [channel getMTU];
 
         // Loop through the data until we have no more to send.
         while ( (result == kIOReturnSuccess) && (numBytesRemaining > 0) ) {
+            if (![channel isOpen]) {
+                result = kIOReturnNotOpen;
+                break;
+            }
+
             // finds how many bytes I can send:
             UInt32 numBytesToSend = ( (numBytesRemaining > rfcommChannelMTU) ? rfcommChannelMTU : numBytesRemaining);
 
             // This method won't return until the buffer has been passed to the Bluetooth hardware to be sent to the remote device.
             // Alternatively, the asynchronous version of this method could be used which would queue up the buffer and return immediately.
-            result = [mRFCOMMChannel writeSync:buffer length:static_cast<UInt16>(numBytesToSend)];
+            result = [channel writeSync:buffer length:static_cast<UInt16>(numBytesToSend)];
 
             // Updates the position in the buffer:
             numBytesRemaining -= numBytesToSend;

--- a/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
@@ -220,8 +220,17 @@
 
     if (channel != nil) {
         if (![channel isOpen]) {
-            [self disconnect];
-            [self signalChannelClosedOnce];
+            // Only tear down if this snapshot is still the current channel; a concurrent
+            // disconnect/reconnect may have already replaced it, and disconnecting here
+            // would kill the fresh connection or re-report an intentional teardown.
+            BOOL isCurrent;
+            @synchronized (self) {
+                isCurrent = (channel == mRFCOMMChannel);
+            }
+            if (isCurrent) {
+                [self disconnect];
+                [self signalChannelClosedOnce];
+            }
             return BT_SEND_ENULL;
         }
         UInt32 numBytesRemaining;

--- a/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
@@ -10,6 +10,7 @@
     NSString *_macAddress;
     Bt_OnChannelData _onChannelData;
     Bt_OnChannelClosed _onChannelClosed;
+    BOOL _channelClosedSignalled;
 }
 
 - (id)init {
@@ -74,7 +75,7 @@
     IOBluetoothSDPServiceRecord *serviceRecord = [device getServiceRecordForUUID:parsedUuid];
 
     if (serviceRecord == nil) {
-        NSLog(@"Error - service in selected device. ***This should never happen.***\n", NULL);
+        NSLog(@"Error - service in selected device. ***This should never happen.***");
         return BT_CONN_ESDP;
     }
 
@@ -95,8 +96,9 @@
     status = [device openRFCOMMChannelSync:&tempRFCOMMChannel withChannelID:rfcommChannelID delegate:self];
     @synchronized (self) {
         mRFCOMMChannel = tempRFCOMMChannel;
+        _channelClosedSignalled = NO;
     }
-    
+
     if (mRFCOMMChannel == nil) {
         NSLog(@"Error: %s - unable to open RFCOMM channel.\n", mach_error_string(status) );
         [self disconnect];
@@ -158,6 +160,22 @@
     return TRUE;
 }
 
+// A remote close (rfcommChannelClosed:) can race an in-flight send hitting the closed
+// channel, and both paths would otherwise fire _onChannelClosed -> a duplicate managed
+// Disconnected event. Signal at most once per connection; reset on the next connect.
+- (void)signalChannelClosedOnce {
+    @synchronized (self) {
+        if (_channelClosedSignalled) {
+            return;
+        }
+        _channelClosedSignalled = YES;
+    }
+
+    if (_onChannelClosed) {
+        _onChannelClosed();
+    }
+}
+
 - (BOOL)isConnected {
     return mRFCOMMChannel != nil;
 }
@@ -203,7 +221,7 @@
     if (channel != nil) {
         if (![channel isOpen]) {
             [self disconnect];
-            if (_onChannelClosed) _onChannelClosed();
+            [self signalChannelClosedOnce];
             return BT_SEND_ENULL;
         }
         UInt32 numBytesRemaining;
@@ -278,9 +296,7 @@
 
 - (void)rfcommChannelClosed:(IOBluetoothRFCOMMChannel *)rfcommChannel {
     [self disconnect];
-    if (_onChannelClosed) {
-        _onChannelClosed();
-    }
+    [self signalChannelClosedOnce];
 }
 
 @end

--- a/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
@@ -203,7 +203,7 @@
     if (channel != nil) {
         if (![channel isOpen]) {
             [self disconnect];
-            _onChannelClosed();
+            if (_onChannelClosed) _onChannelClosed();
             return BT_SEND_ENULL;
         }
         UInt32 numBytesRemaining;

--- a/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/Bluetooth.mm
@@ -167,10 +167,12 @@
     for (int i = 0; i < result->length; i++) {
         Device *resultDevice = &result->devices[i];
         IOBluetoothDevice *device = [inDevices objectAtIndex:i];
-        resultDevice->device_name = (char *)malloc([device.name lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        resultDevice->mac_address = (char *)malloc([device.addressString lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        strcpy(resultDevice->device_name, device.name.UTF8String);
-        strcpy(resultDevice->mac_address, device.addressString.UTF8String);
+        // name/addressString can be nil (e.g. paired device with unresolved
+        // name); a nil NSString yields a NULL UTF8String and strcpy(NULL) crashes.
+        const char *deviceName = device.name.UTF8String;
+        const char *macAddress = device.addressString.UTF8String;
+        resultDevice->device_name = strdup(deviceName ? deviceName : "");
+        resultDevice->mac_address = strdup(macAddress ? macAddress : "");
         resultDevice->is_connected = device.isConnected;
         resultDevice->is_paired = device.isPaired;
         resultDevice->cod = device.classOfDevice;

--- a/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.h
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.h
@@ -13,6 +13,7 @@ typedef void (*BtDev_OnDisconnected)(const char *mac);
 
 @interface BluetoothDeviceWatcher : NSObject
 - (id)init;
+- (void)teardown;
 - (BOOL)registerForDisconnectNotification:(NSString *)mac;
 - (void)setOnConnected:(BtDev_OnConnected)callback;
 - (void)setOnDisconnected:(BtDev_OnDisconnected)callback;

--- a/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
@@ -12,6 +12,7 @@
 @implementation BluetoothDeviceWatcher {
     BtDev_OnConnected _onConnected;
     BtDev_OnDisconnected _onDisconnected;
+    IOBluetoothUserNotification *mDisconnectNotification;
 }
 - (id)init {
     if (self = [super init]) {
@@ -30,8 +31,13 @@
         return FALSE;
     }
 
-    [dev registerForDisconnectNotification:self
-                                  selector:@selector(onDisconnected:fromDevice:)];
+    // Re-registering without unregistering stacks notifications: one physical
+    // disconnect would then fire the managed callback once per stale handle.
+    if (mDisconnectNotification != nil) {
+        [mDisconnectNotification unregister];
+    }
+    mDisconnectNotification = [dev registerForDisconnectNotification:self
+                                                            selector:@selector(onDisconnected:fromDevice:)];
     return TRUE;
 }
 

--- a/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
@@ -12,15 +12,30 @@
 @implementation BluetoothDeviceWatcher {
     BtDev_OnConnected _onConnected;
     BtDev_OnDisconnected _onDisconnected;
+    IOBluetoothUserNotification *mConnectNotification;
     IOBluetoothUserNotification *mDisconnectNotification;
 }
 - (id)init {
     if (self = [super init]) {
-        [IOBluetoothDevice registerForConnectNotifications:self
+        mConnectNotification = [IOBluetoothDevice registerForConnectNotifications:self
                                                   selector:@selector(onConnected:fromDevice:)];
     }
 
     return self;
+}
+
+// IOBluetooth user-notifications retain their target (self), so they must be
+// explicitly unregistered before the watcher can be released — relying on dealloc
+// would deadlock, since the notification keeps self alive. Called from bt_free.
+- (void)teardown {
+    if (mConnectNotification != nil) {
+        [mConnectNotification unregister];
+        mConnectNotification = nil;
+    }
+    if (mDisconnectNotification != nil) {
+        [mDisconnectNotification unregister];
+        mDisconnectNotification = nil;
+    }
 }
 
 - (BOOL)registerForDisconnectNotification:(NSString *)mac {

--- a/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/BluetoothDeviceWatcher.mm
@@ -43,20 +43,33 @@
     _onDisconnected = callback;
 }
 
+// addressString/nameOrAddress can be nil while the device record is still
+// populating; a nil NSString yields a NULL UTF8String and strcpy(NULL) crashes.
+static char *copyUTF8OrNull(NSString *str) {
+    const char *utf8 = str.UTF8String;
+    return utf8 ? strdup(utf8) : NULL;
+}
+
 - (void)onConnected:(IOBluetoothUserNotification *)notification fromDevice:(IOBluetoothDevice *)device {
     if (_onConnected) {
-        char *mac = (char *)malloc([[device addressString] lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        char *name = (char *)malloc([[device nameOrAddress] lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        strcpy(mac, device.addressString.UTF8String);
-        strcpy(name, device.nameOrAddress.UTF8String);
+        char *mac = copyUTF8OrNull(device.addressString);
+        if (mac == NULL) {
+            return;
+        }
+        char *name = copyUTF8OrNull(device.nameOrAddress);
+        if (name == NULL) {
+            name = strdup(mac);
+        }
         _onConnected(mac, name);
     }
 }
 
 - (void)onDisconnected:(IOBluetoothUserNotification *)notification fromDevice:(IOBluetoothDevice *)device {
     if (_onDisconnected) {
-        char *mac = (char *)malloc([[device addressString] lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1);
-        strcpy(mac, device.addressString.UTF8String);
+        char *mac = copyUTF8OrNull(device.addressString);
+        if (mac == NULL) {
+            return;
+        }
         _onDisconnected(mac);
     }
 }

--- a/GalaxyBudsClient.Platform.OSX/Native/src/bridge/Native.Bluetooth.mm
+++ b/GalaxyBudsClient.Platform.OSX/Native/src/bridge/Native.Bluetooth.mm
@@ -6,17 +6,33 @@
 #import "Native.h"
 
 bool bt_alloc(BluetoothImpl **self) {
-    *self = (BluetoothImpl *)malloc(sizeof(struct BluetoothImpl));
+    // calloc (not malloc): the struct's client/watcher are ARC __strong members, so the slots must
+    // start nil — assigning into uninitialised memory would make ARC release a garbage pointer.
+    *self = (BluetoothImpl *)calloc(1, sizeof(struct BluetoothImpl));
+    if (*self == nullptr) {
+        return false;
+    }
 
     (*self)->client = [[Bluetooth alloc] init];
     (*self)->watcher = [[BluetoothDeviceWatcher alloc] init];
 
-    return (*self) != nullptr &&
-           (*self)->client != nullptr &&
+    return (*self)->client != nullptr &&
            (*self)->watcher != nullptr;
 }
 
 void bt_free(BluetoothImpl *self) {
+    if (self == nullptr) {
+        return;
+    }
+
+    // A raw free() does not run ARC's release of the struct's __strong members, and the watcher's
+    // IOBluetooth notifications retain it. Tear those down and close the channel, then nil the
+    // members so ARC releases the objects, before freeing the struct.
+    [self->watcher teardown];
+    [self->client disconnect];
+    self->client = nil;
+    self->watcher = nil;
+
     free(self);
 }
 

--- a/GalaxyBudsClient/App.axaml.cs
+++ b/GalaxyBudsClient/App.axaml.cs
@@ -109,6 +109,12 @@ public class App : Application
             _ = TrayManager.Instance.RebuildAsync();
         }
         
+        // Subscribe BEFORE MainWindow (and its page viewmodels) is constructed: handlers fire in
+        // subscription order, and EqualizerPageViewModel's ESU handler persists CustomEqualizerEnabled.
+        // Our one-shot ReapplyCustomEqualizerAsync must read that flag before the VM can overwrite it,
+        // or a post-power-cycle ESU reporting a non-custom mode would silently kill the re-push.
+        SppMessageReceiver.Instance.ExtendedStatusUpdate += OnExtendedStatusUpdate;
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             // Initialize MainWindow singleton
@@ -143,8 +149,9 @@ public class App : Application
         BluetoothImpl.Instance.Connected += OnConnected;
         SppMessageReceiver.Instance.StatusUpdate += OnStatusUpdate;
         SppMessageReceiver.Instance.OtherOption += HandleOtherTouchOption;
-        SppMessageReceiver.Instance.ExtendedStatusUpdate += OnExtendedStatusUpdate;
-        
+        // ExtendedStatusUpdate subscribed earlier (before MainWindow) — see comment there
+        SppMessageReceiver.Instance.NoiseControlUpdateResponse += OnNoiseControlUpdate;
+
         DeviceMessageCache.Init();
         
         if (Loc.IsTranslatorModeEnabled)
@@ -238,6 +245,18 @@ public class App : Application
             _customEqReapplied = true;
             _ = ReapplyCustomEqualizerAsync();
         }
+    }
+
+    // The firmware drops the custom EQ band table on every noise-control switch (ANC/Ambient/Off),
+    // not just on power-cycle, so re-push it whenever the buds report a mode change. Listening to the
+    // dedicated NoiseControlUpdate signal avoids the case-open/on-head/battery churn that re-pushing
+    // on every ExtendedStatusUpdate caused.
+    private void OnNoiseControlUpdate(object? sender, NoiseControlModes e)
+    {
+        // Table-drop on NC switch only observed on Buds4 Pro; don't override phone-side
+        // EQ choices on other CustomEqualizer models where the table survives the switch.
+        if (BluetoothImpl.Instance.CurrentModel == Models.Buds4Pro)
+            _ = ReapplyCustomEqualizerAsync();
     }
 
     // The custom EQ band table is not retained by the firmware across power cycles, so the values

--- a/GalaxyBudsClient/App.axaml.cs
+++ b/GalaxyBudsClient/App.axaml.cs
@@ -183,15 +183,19 @@ public class App : Application
         {
             _popup.UpdateSettings();
             _popup.RearmTimer();
+            return;
         }
         
         Dialogs.ShowAsSingleInstanceOnDesktop(ref _popup); 
         _popupShown = true;
     }
     
+    private bool _customEqReapplied;
+
     private void OnConnected(object? sender, EventArgs e)
     {
         _popupShown = false;
+        _customEqReapplied = false;
     }
 
     private void OnBluetoothError(object? sender, BluetoothException e)
@@ -204,6 +208,7 @@ public class App : Application
     {
         WindowIconRenderer.ResetIconToDefault();
         _popupShown = false;
+        _customEqReapplied = false;
     }
     
     private void OnExtendedStatusUpdate(object? sender, ExtendedStatusUpdateDecoder e)
@@ -224,8 +229,15 @@ public class App : Application
         if(BluetoothImpl.Instance.DeviceSpec.Supports(Features.DebugSku))
             _ = BluetoothImpl.Instance.SendRequestAsync(MsgIds.DEBUG_SKU);
 
-        // Re-apply the saved custom EQ; the firmware drops the custom band table on power-cycle
-        _ = ReapplyCustomEqualizerAsync();
+        // Re-apply the saved custom EQ ONCE per connection. ExtendedStatusUpdate also arrives on
+        // routine state changes (case open/close, on-head, noise-control switches); re-pushing the
+        // EQ on every one caused an audible mid-session re-application. The firmware drops the
+        // custom table on power-cycle, so a single re-push per connect is enough.
+        if (!_customEqReapplied)
+        {
+            _customEqReapplied = true;
+            _ = ReapplyCustomEqualizerAsync();
+        }
     }
 
     // The custom EQ band table is not retained by the firmware across power cycles, so the values
@@ -254,12 +266,21 @@ public class App : Application
 
     private static void OnDispatcherUnhandledException(object? sender, DispatcherUnhandledExceptionEventArgs e)
     {
-        var trace = e.Exception.StackTrace;
-        if (trace != null && trace.Contains("AutomationPeer"))
+        // Swallow ONLY FluentAvalonia's ItemsRepeaterAutomationPeer.GetChildrenCore() NRE, raised by
+        // the macOS accessibility bridge while walking the automation tree. Match precisely (specific
+        // type + method, unwrapping inner/aggregate exceptions) so genuine bugs still crash/report.
+        for (Exception? ex = e.Exception; ex != null; ex = ex.InnerException)
         {
-            Log.Warning(e.Exception,
-                "Suppressed non-fatal automation-peer exception raised by the accessibility bridge");
-            e.Handled = true;
+            if (ex is NullReferenceException &&
+                ex.StackTrace is { } trace &&
+                trace.Contains("ItemsRepeaterAutomationPeer") &&
+                trace.Contains("GetChildrenCore"))
+            {
+                Log.Warning(e.Exception,
+                    "Suppressed non-fatal automation-peer exception raised by the accessibility bridge");
+                e.Handled = true;
+                return;
+            }
         }
     }
 

--- a/GalaxyBudsClient/App.axaml.cs
+++ b/GalaxyBudsClient/App.axaml.cs
@@ -94,6 +94,15 @@ public class App : Application
     
     public override void OnFrameworkInitializationCompleted()
     {
+        // FluentAvalonia 2.4.1's ItemsRepeaterAutomationPeer.GetChildrenCore() can throw an
+        // unguarded NullReferenceException when the macOS accessibility bridge walks the automation
+        // tree while a repeater is mid-virtualization (e.g. during a navigation/relayout triggered
+        // by changing a setting). Upstream never guarded this, and the exception otherwise
+        // propagates out of the dispatcher loop and kills the whole app. Swallow only that specific
+        // accessibility-tree failure — it is benign and affects an assistive-technology query, not
+        // the UI itself — while letting every other exception crash and report as before.
+        Dispatcher.UIThread.UnhandledException += OnDispatcherUnhandledException;
+
         if (BluetoothImpl.HasValidDevice)
         {
             Task.Run(() => BluetoothImpl.Instance.ConnectAsync());
@@ -106,10 +115,13 @@ public class App : Application
             var mainWindow = MainWindow.Instance;
             
 #if OSX
-            // On macOS with LSUIElement=true, always start as a menu bar app (no main window attached initially)
-            // The window will be shown when the user clicks the tray icon
-            desktop.MainWindow = null;
-            mainWindow.IsVisible = false;
+            // Show the main window on launch (unless started with /StartMinimized); the menu bar
+            // icon stays available either way. When we show it, restore the dock icon that
+            // Initialize() hid for the menu-bar-app case.
+            desktop.MainWindow = StartMinimized ? null : mainWindow;
+            mainWindow.IsVisible = !StartMinimized;
+            if (!StartMinimized)
+                GalaxyBudsClient.Platform.OSX.AppUtils.setHideInDock(false);
 #else
             // Stay initially minimized: don't attach a main window
             desktop.MainWindow = StartMinimized ? null : mainWindow;
@@ -211,8 +223,46 @@ public class App : Application
         _ = BluetoothImpl.Instance.SendAsync(new ManagerInfoEncoder());
         if(BluetoothImpl.Instance.DeviceSpec.Supports(Features.DebugSku))
             _ = BluetoothImpl.Instance.SendRequestAsync(MsgIds.DEBUG_SKU);
+
+        // Re-apply the saved custom EQ; the firmware drops the custom band table on power-cycle
+        _ = ReapplyCustomEqualizerAsync();
     }
-    
+
+    // The custom EQ band table is not retained by the firmware across power cycles, so the values
+    // are persisted per-device (see EqualizerPageViewModel.PersistCustomEq) and re-pushed here on
+    // every connect, mirroring what the official Galaxy Wearable app does.
+    private static async Task ReapplyCustomEqualizerAsync()
+    {
+        if (!BluetoothImpl.Instance.DeviceSpec.Supports(Features.CustomEqualizer))
+            return;
+        if (BluetoothImpl.Instance.Device.Current is not { CustomEqualizerEnabled: true } device ||
+            device.CustomEqualizerBands is not { Length: 9 } bands)
+            return;
+
+        await BluetoothImpl.Instance.SendAsync(new SetCustomEqualizerEncoder
+        {
+            BandGains =
+            [
+                (sbyte)bands[0], (sbyte)bands[1], (sbyte)bands[2],
+                (sbyte)bands[3], (sbyte)bands[4], (sbyte)bands[5],
+                (sbyte)bands[6], (sbyte)bands[7], (sbyte)bands[8]
+            ]
+        });
+        // Samsung preset index 6 = custom; the EQUALIZER message carries index + 1 (7)
+        await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder { IsEnabled = true, Preset = 6 });
+    }
+
+    private static void OnDispatcherUnhandledException(object? sender, DispatcherUnhandledExceptionEventArgs e)
+    {
+        var trace = e.Exception.StackTrace;
+        if (trace != null && trace.Contains("AutomationPeer"))
+        {
+            Log.Warning(e.Exception,
+                "Suppressed non-fatal automation-peer exception raised by the accessibility bridge");
+            e.Handled = true;
+        }
+    }
+
     private void OnStatusUpdate(object? sender, StatusUpdateDecoder e)
     {
         if (_lastWearState == LegacyWearStates.None &&

--- a/GalaxyBudsClient/Interface/Converters/AmbientStrengthConverter.cs
+++ b/GalaxyBudsClient/Interface/Converters/AmbientStrengthConverter.cs
@@ -7,8 +7,8 @@ namespace GalaxyBudsClient.Interface.Converters;
 
 public class AmbientStrengthConverter : IntToStringConverter
 {
-    private bool _legacy;
-        
+    private Models _model;
+
     public AmbientStrengthConverter()
     {
         SelectScale();
@@ -17,9 +17,9 @@ public class AmbientStrengthConverter : IntToStringConverter
 
     private void SelectScale()
     {
-        _legacy = BluetoothImpl.Instance.CurrentModel == Models.Buds;
+        _model = BluetoothImpl.Instance.CurrentModel;
     }
-    
+
     private static Dictionary<int, string> LegacyScale => new()
     {
         { 0, Strings.AsScaleVeryLow },
@@ -31,6 +31,15 @@ public class AmbientStrengthConverter : IntToStringConverter
 
     private static Dictionary<int, string> Scale => new()
     {
+        { 0, Strings.AsScaleLow },
+        { 1, Strings.AsScaleModerate },
+        { 2, Strings.AsScaleHigh },
+        { 3, Strings.AsScaleExtraloud }
+    };
+
+    // ponytail: Buds4 Pro's 5-step scale has no dedicated i18n keys yet; add Strings entries if upstreamed
+    private static Dictionary<int, string> ExtendedScale => new()
+    {
         { 0, "Level 1" },
         { 1, "Level 2" },
         { 2, "Level 3" },
@@ -38,5 +47,10 @@ public class AmbientStrengthConverter : IntToStringConverter
         { 4, "Level 5" }
     };
 
-    protected override Dictionary<int, string> Mapping => _legacy ? LegacyScale : Scale;
+    protected override Dictionary<int, string> Mapping => _model switch
+    {
+        Models.Buds => LegacyScale,
+        Models.Buds4Pro => ExtendedScale,
+        _ => Scale
+    };
 }

--- a/GalaxyBudsClient/Interface/Converters/AmbientStrengthConverter.cs
+++ b/GalaxyBudsClient/Interface/Converters/AmbientStrengthConverter.cs
@@ -31,10 +31,11 @@ public class AmbientStrengthConverter : IntToStringConverter
 
     private static Dictionary<int, string> Scale => new()
     {
-        { 0, Strings.AsScaleLow },
-        { 1, Strings.AsScaleModerate },
-        { 2, Strings.AsScaleHigh },
-        { 3, Strings.AsScaleExtraloud }
+        { 0, "Level 1" },
+        { 1, "Level 2" },
+        { 2, "Level 3" },
+        { 3, "Level 4" },
+        { 4, "Level 5" }
     };
 
     protected override Dictionary<int, string> Mapping => _legacy ? LegacyScale : Scale;

--- a/GalaxyBudsClient/Interface/Developer/DevTools.axaml
+++ b/GalaxyBudsClient/Interface/Developer/DevTools.axaml
@@ -5,7 +5,7 @@
         xmlns:developer="clr-namespace:GalaxyBudsClient.Interface.Developer"
         mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="625"
         x:Class="GalaxyBudsClient.Interface.Developer.DevTools"
-        Height="625" Width="700"
+        Height="680" Width="940"
         ShowInTaskbar="True"
         WindowStartupLocation="CenterScreen"
         Icon="/Resources/icon.ico"

--- a/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml
+++ b/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml
@@ -72,13 +72,22 @@
                                 <ColumnDefinition Width="*" MaxWidth="100" />
                             </Grid.ColumnDefinitions>
                             
-                            <AutoCompleteBox Grid.Column="0" Name="SendMsgId"
-                                             HorizontalAlignment="Stretch"
-                                             Margin="0,0,5,0"
-                                             Watermark="Search message ID"
-                                             FilterMode="Contains"
-                                             MinimumPrefixLength="0"
-                                             MaxDropDownHeight="400" />
+                            <DockPanel Grid.Column="0" Margin="0,0,5,0">
+                                <Button DockPanel.Dock="Right"
+                                        Name="OpenMsgIdList"
+                                        Content="&#x25BE;"
+                                        Width="30"
+                                        Margin="2,0,0,0"
+                                        VerticalAlignment="Stretch"
+                                        Click="OpenMsgIdList_Click" />
+                                <AutoCompleteBox Name="SendMsgId"
+                                                 HorizontalAlignment="Stretch"
+                                                 MinWidth="190"
+                                                 Watermark="Search message ID"
+                                                 FilterMode="Contains"
+                                                 MinimumPrefixLength="0"
+                                                 MaxDropDownHeight="400" />
+                            </DockPanel>
                             <ComboBox Grid.Column="1" Name="SendMsgType"
                                       Margin="0,0,5,0"
                                       HorizontalAlignment="Stretch"

--- a/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml
+++ b/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml
@@ -44,9 +44,21 @@
             </MenuItem>
         </Menu>
 
-        <Grid Margin="3, 0, 3, 3" ColumnDefinitions="Auto,5,*">
+        <Grid Margin="3, 0, 3, 3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" MinWidth="240" />
+                <ColumnDefinition Width="5" />
+                <ColumnDefinition Width="3*" MinWidth="280" />
+            </Grid.ColumnDefinitions>
 
-            <Grid Grid.Column="0" RowDefinitions="*,5,*">
+
+            <Grid Grid.Column="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" MinHeight="100" />
+                    <RowDefinition Height="5" />
+                    <RowDefinition Height="*" MinHeight="110" />
+                </Grid.RowDefinitions>
+
 
                 <avaloniaHex:HexEditor Name="HexEditor"
                                        Grid.Column="0" 
@@ -77,12 +89,14 @@
                                         Name="OpenMsgIdList"
                                         Content="&#x25BE;"
                                         Width="30"
+                                        Padding="0"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
                                         Margin="2,0,0,0"
                                         VerticalAlignment="Stretch"
                                         Click="OpenMsgIdList_Click" />
                                 <AutoCompleteBox Name="SendMsgId"
                                                  HorizontalAlignment="Stretch"
-                                                 MinWidth="190"
                                                  Watermark="Search message ID"
                                                  FilterMode="Contains"
                                                  MinimumPrefixLength="0"
@@ -109,7 +123,13 @@
 
             <GridSplitter Grid.Column="1" Width="5" ShowsPreview="True" />
 
-            <Grid Grid.Column="2" RowDefinitions="*,5,*">
+            <Grid Grid.Column="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" MinHeight="100" />
+                    <RowDefinition Height="5" />
+                    <RowDefinition Height="*" MinHeight="100" />
+                </Grid.RowDefinitions>
+
                 <DataGrid Name="MsgTable" Grid.Row="0" SelectionMode="Single"
                           CanUserSortColumns="False" CanUserReorderColumns="False"
                           CanUserResizeColumns="True"

--- a/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml
+++ b/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml
@@ -72,10 +72,13 @@
                                 <ColumnDefinition Width="*" MaxWidth="100" />
                             </Grid.ColumnDefinitions>
                             
-                            <ComboBox Grid.Column="0" Name="SendMsgId"
-                                      HorizontalAlignment="Stretch"
-                                      Margin="0,0,5,0"
-                                      ItemsSource="{Binding ., Source={ext:MsgIdsBindingSource}}" />
+                            <AutoCompleteBox Grid.Column="0" Name="SendMsgId"
+                                             HorizontalAlignment="Stretch"
+                                             Margin="0,0,5,0"
+                                             Watermark="Search message ID"
+                                             FilterMode="Contains"
+                                             MinimumPrefixLength="0"
+                                             MaxDropDownHeight="400" />
                             <ComboBox Grid.Column="1" Name="SendMsgType"
                                       Margin="0,0,5,0"
                                       HorizontalAlignment="Stretch"

--- a/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml
+++ b/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml
@@ -18,8 +18,27 @@
 
     <UserControl.Styles>
         <Style Selector="DataGridCell">
-            <Setter Property="FontSize" Value="14" />
-            <Setter Property="MinHeight" Value="24" />
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="MinHeight" Value="19" />
+            <Setter Property="Padding" Value="4,1" />
+        </Style>
+        <Style Selector="DataGridColumnHeader">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="MinHeight" Value="22" />
+        </Style>
+        <!-- The Fluent AutoCompleteBox template otherwise grows the dropdown to the widest message-ID
+             string. Give the suggestions container a fixed width (the search box itself is far too
+             narrow to bind to) so it's a stable, readable size, with a compact list font and rows. -->
+        <Style Selector="AutoCompleteBox#SendMsgId /template/ Border#PART_SuggestionsContainer">
+            <Setter Property="Width" Value="280" />
+        </Style>
+        <Style Selector="AutoCompleteBox#SendMsgId /template/ ListBox#PART_SelectingItemsControl">
+            <Setter Property="FontSize" Value="11" />
+        </Style>
+        <Style Selector="AutoCompleteBox#SendMsgId /template/ ListBox#PART_SelectingItemsControl ListBoxItem">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Padding" Value="8,2" />
+            <Setter Property="MinHeight" Value="0" />
         </Style>
         <StyleInclude Source="avares://AvaloniaHex/Themes/Simple/AvaloniaHex.axaml"/>
     </UserControl.Styles>

--- a/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
+++ b/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
@@ -123,6 +123,13 @@ public partial class DevToolsView : UserControl
         }
     }
        
+    private void OpenMsgIdList_Click(object? sender, RoutedEventArgs e)
+    {
+        SendMsgId.Text ??= string.Empty;
+        SendMsgId.PopulateComplete();
+        SendMsgId.IsDropDownOpen = true;
+    }
+
     private void SendMsg_Click(object? sender, RoutedEventArgs e)
     {
         if (SendMsgId.SelectedItem == null || SendMsgType.SelectedItem == null)

--- a/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
+++ b/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
@@ -39,6 +39,7 @@ public partial class DevToolsView : UserControl
         HexEditor.FontFamily = monoFonts;
         
         DataContext = new DevToolsViewModel();
+        SendMsgId.ItemsSource = Enum.GetValues<MsgIds>().OrderBy(x => x.ToString()).ToList();
         
         ViewModel.PropertyChanged += OnPropertyChanged;
         BluetoothImpl.Instance.NewDataReceived += OnNewDataReceived;

--- a/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
+++ b/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
@@ -40,7 +40,9 @@ public partial class DevToolsView : UserControl
         
         DataContext = new DevToolsViewModel();
         SendMsgId.ItemsSource = Enum.GetValues<MsgIds>().OrderBy(x => x.ToString()).ToList();
-        
+        // Default the message-type selector to Request so it doesn't require a pick every time
+        SendMsgType.SelectedItem = MsgTypes.Request;
+
         ViewModel.PropertyChanged += OnPropertyChanged;
         BluetoothImpl.Instance.NewDataReceived += OnNewDataReceived;
     }

--- a/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
+++ b/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
@@ -107,7 +107,12 @@ public partial class DevToolsView : UserControl
 
     protected override void OnUnloaded(RoutedEventArgs e)
     {
+        // Remove every handler added in the ctor / SelectProtocol — otherwise, if the view is
+        // unloaded while the alternative protocol is active, NewDataReceivedAlternative (and the
+        // VM PropertyChanged) keep this dead view alive on the BluetoothImpl singleton.
         BluetoothImpl.Instance.NewDataReceived -= OnNewDataReceived;
+        BluetoothImpl.Instance.NewDataReceivedAlternative -= OnNewDataReceived;
+        ViewModel.PropertyChanged -= OnPropertyChanged;
 
         HexEditor.Document = null;
         ViewModel.MsgTableDataSource.Clear();

--- a/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
+++ b/GalaxyBudsClient/Interface/Developer/DevToolsView.axaml.cs
@@ -139,7 +139,13 @@ public partial class DevToolsView : UserControl
 
     private void SendMsg_Click(object? sender, RoutedEventArgs e)
     {
-        if (SendMsgId.SelectedItem == null || SendMsgType.SelectedItem == null)
+        // AutoCompleteBox only sets SelectedItem when a dropdown suggestion is committed;
+        // typed or edited text must be parsed from Text to avoid null/stale SelectedItem.
+        MsgIds? msgId = Enum.TryParse<MsgIds>(SendMsgId.Text?.Trim() ?? "", ignoreCase: true, out var parsedMsgId)
+            ? parsedMsgId
+            : SendMsgId.SelectedItem as MsgIds?;
+
+        if (msgId == null || SendMsgType.SelectedItem == null)
         {
             _ = new MessageBox
             {
@@ -166,7 +172,7 @@ public partial class DevToolsView : UserControl
 
         if (ViewModel.UseAlternativeProtocol)
         {
-            var msg = new SppAlternativeMessage((MsgIds?)SendMsgId.SelectedItem ?? MsgIds.UNKNOWN_0,
+            var msg = new SppAlternativeMessage(msgId.Value,
                 payload,
                 (MsgTypes?)SendMsgType.SelectedItem ?? MsgTypes.Request);
             _ = BluetoothImpl.Instance.SendAltAsync(msg);
@@ -175,7 +181,7 @@ public partial class DevToolsView : UserControl
         {
             var msg = new SppMessage
             {
-                Id = (MsgIds?)SendMsgId.SelectedItem ?? MsgIds.UNKNOWN_0,
+                Id = msgId.Value,
                 Payload = payload,
                 Type = (MsgTypes?)SendMsgType.SelectedItem ?? MsgTypes.Request
             };

--- a/GalaxyBudsClient/Interface/Dialogs/BudsPopup.axaml.cs
+++ b/GalaxyBudsClient/Interface/Dialogs/BudsPopup.axaml.cs
@@ -67,6 +67,14 @@ public partial class BudsPopup : Window
         base.OnOpened(e);
     }
 
+    protected override void OnClosed(EventArgs e)
+    {
+        // The popup is recreated each cycle (Hide -> Close), so detach from the static settings
+        // event or every closed instance leaks and keeps receiving settings changes.
+        Settings.MainSettingsPropertyChanged -= OnMainSettingsPropertyChanged;
+        base.OnClosed(e);
+    }
+
     private void Window_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         ClickedEventHandler?.Invoke(this, EventArgs.Empty);

--- a/GalaxyBudsClient/Interface/Pages/AmbientCustomizePage.axaml
+++ b/GalaxyBudsClient/Interface/Pages/AmbientCustomizePage.axaml
@@ -23,6 +23,7 @@
             
             <controls:SettingsGroup>
                 <controls:SettingsSliderItem
+                    Debounce="True"
                     Content="{ext:Translate {x:Static i18N:Keys.AsVolume}}"
                     Description="{Binding AmbientSoundVolume, Converter={StaticResource AmbientStrengthConverter}}"
                     Symbol="Gauge"
@@ -68,6 +69,7 @@
                     IsChecked="{Binding IsAmbientCustomizationEnabled}" />
 
                 <controls:SettingsSliderItem
+                    Debounce="True"
                     Content="{ext:Translate {x:Static i18N:Keys.NcAsCustomVolumeL}}"
                     Description="{Binding AmbientSoundVolumeLeft, Converter={StaticResource AmbientCustomStrengthConverter}}"
                     Symbol="ArrowStepInLeft"
@@ -80,6 +82,7 @@
                 </controls:SettingsSliderItem>
 
                 <controls:SettingsSliderItem
+                    Debounce="True"
                     Content="{ext:Translate {x:Static i18N:Keys.NcAsCustomVolumeR}}"
                     Description="{Binding AmbientSoundVolumeRight, Converter={StaticResource AmbientCustomStrengthConverter}}"
                     Symbol="ArrowStepInRight"
@@ -92,6 +95,7 @@
                 </controls:SettingsSliderItem>
                 
                 <controls:SettingsSliderItem
+                    Debounce="True"
                     Content="{ext:Translate {x:Static i18N:Keys.NcAsCustomTone}}"
                     Description="{Binding AmbientSoundTone, Converter={StaticResource AmbientToneConverter}}"
                     Symbol="SoundSource"

--- a/GalaxyBudsClient/Interface/Pages/EqualizerPage.axaml
+++ b/GalaxyBudsClient/Interface/Pages/EqualizerPage.axaml
@@ -22,41 +22,19 @@
             </Interaction.Behaviors>
             
             <controls:SettingsGroup>
-                <controls:SettingsSwitchItem
-                    Content="{ext:Translate {x:Static i18N:Keys.EqEnable}}"
-                    Description="{ext:Translate {x:Static i18N:Keys.EqEnableDescription}}"
+                <controls:SettingsComboBoxItem
+                    Content="{ext:Translate {x:Static i18N:Keys.EqHeader}}"
+                    Description="Choose a preset, Custom for your own 9-band curve, or Off"
                     Symbol="DeviceEq"
-                    IsChecked="{Binding IsEqEnabled}" />
-
-                <controls:SettingsSliderItem
-                    Name="EqPreset"
-                    Content="{ext:Translate {x:Static i18N:Keys.EqPreset}}"
-                    Description="{Binding EqPreset, Converter={StaticResource EqPresetConverter}}"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    Maximum="{Binding MaximumEqPreset}"
-                    Value="{Binding EqPreset}">
-                    <controls:SettingsSliderItem.IsEnabled>
-                        <MultiBinding Converter="{x:Static BoolConverters.And}">
-                            <Binding Path="IsEqEnabled" />
-                            <Binding Path="!IsCustomEqEnabled" />
-                        </MultiBinding>
-                    </controls:SettingsSliderItem.IsEnabled>
-                    <Interaction.Behaviors>
-                        <ext:LocalizationAwareSliderBehavior Converter="{StaticResource EqPresetConverter}" />
-                    </Interaction.Behaviors>
-                </controls:SettingsSliderItem>
+                    ItemsSource="{Binding EqOptions}"
+                    DisplayMemberBinding="{Binding}"
+                    SelectedValue="{Binding SelectedEqOption}" />
             </controls:SettingsGroup>
 
             <controls:SettingsGroup>
                 <Interaction.Behaviors>
                     <ext:RequiresFeatureBehavior Feature="CustomEqualizer" />
                 </Interaction.Behaviors>
-
-                <controls:SettingsSwitchItem
-                    Content="Custom equalizer"
-                    Description="Set your own 9-band curve instead of a preset (low to high frequency, -10 to +10)"
-                    Symbol="Options"
-                    IsChecked="{Binding IsCustomEqEnabled}" />
 
                 <Border IsEnabled="{Binding IsCustomEqEnabled}" Margin="12,8">
                     <Grid ColumnDefinitions="*,*,*,*,*,*,*,*,*">

--- a/GalaxyBudsClient/Interface/Pages/EqualizerPage.axaml
+++ b/GalaxyBudsClient/Interface/Pages/EqualizerPage.axaml
@@ -33,9 +33,14 @@
                     Content="{ext:Translate {x:Static i18N:Keys.EqPreset}}"
                     Description="{Binding EqPreset, Converter={StaticResource EqPresetConverter}}"
                     IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsEqEnabled}"
                     Maximum="{Binding MaximumEqPreset}"
                     Value="{Binding EqPreset}">
+                    <controls:SettingsSliderItem.IsEnabled>
+                        <MultiBinding Converter="{x:Static BoolConverters.And}">
+                            <Binding Path="IsEqEnabled" />
+                            <Binding Path="!IsCustomEqEnabled" />
+                        </MultiBinding>
+                    </controls:SettingsSliderItem.IsEnabled>
                     <Interaction.Behaviors>
                         <ext:LocalizationAwareSliderBehavior Converter="{StaticResource EqPresetConverter}" />
                     </Interaction.Behaviors>
@@ -53,87 +58,73 @@
                     Symbol="Options"
                     IsChecked="{Binding IsCustomEqEnabled}" />
 
-                <controls:SettingsSliderItem
-                    Content="Band 1"
-                    Description="{Binding Band1}"
-                    Debounce="True"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsCustomEqEnabled}"
-                    Minimum="-10"
-                    Maximum="10"
-                    Value="{Binding Band1}" />
-                <controls:SettingsSliderItem
-                    Content="Band 2"
-                    Description="{Binding Band2}"
-                    Debounce="True"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsCustomEqEnabled}"
-                    Minimum="-10"
-                    Maximum="10"
-                    Value="{Binding Band2}" />
-                <controls:SettingsSliderItem
-                    Content="Band 3"
-                    Description="{Binding Band3}"
-                    Debounce="True"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsCustomEqEnabled}"
-                    Minimum="-10"
-                    Maximum="10"
-                    Value="{Binding Band3}" />
-                <controls:SettingsSliderItem
-                    Content="Band 4"
-                    Description="{Binding Band4}"
-                    Debounce="True"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsCustomEqEnabled}"
-                    Minimum="-10"
-                    Maximum="10"
-                    Value="{Binding Band4}" />
-                <controls:SettingsSliderItem
-                    Content="Band 5"
-                    Description="{Binding Band5}"
-                    Debounce="True"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsCustomEqEnabled}"
-                    Minimum="-10"
-                    Maximum="10"
-                    Value="{Binding Band5}" />
-                <controls:SettingsSliderItem
-                    Content="Band 6"
-                    Description="{Binding Band6}"
-                    Debounce="True"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsCustomEqEnabled}"
-                    Minimum="-10"
-                    Maximum="10"
-                    Value="{Binding Band6}" />
-                <controls:SettingsSliderItem
-                    Content="Band 7"
-                    Description="{Binding Band7}"
-                    Debounce="True"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsCustomEqEnabled}"
-                    Minimum="-10"
-                    Maximum="10"
-                    Value="{Binding Band7}" />
-                <controls:SettingsSliderItem
-                    Content="Band 8"
-                    Description="{Binding Band8}"
-                    Debounce="True"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsCustomEqEnabled}"
-                    Minimum="-10"
-                    Maximum="10"
-                    Value="{Binding Band8}" />
-                <controls:SettingsSliderItem
-                    Content="Band 9"
-                    Description="{Binding Band9}"
-                    Debounce="True"
-                    IconSource="{StaticResource IconPlaceholder}"
-                    IsEnabled="{Binding IsCustomEqEnabled}"
-                    Minimum="-10"
-                    Maximum="10"
-                    Value="{Binding Band9}" />
+                <Border IsEnabled="{Binding IsCustomEqEnabled}" Margin="12,8">
+                    <Grid ColumnDefinitions="*,*,*,*,*,*,*,*,*">
+                        <StackPanel Grid.Column="0" Spacing="4" HorizontalAlignment="Stretch">
+                            <TextBlock Text="{Binding Band1}" HorizontalAlignment="Center" FontSize="12" />
+                            <Slider Orientation="Vertical" Height="180" HorizontalAlignment="Center"
+                                    Minimum="-10" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                    Value="{Binding Band1}" />
+                            <TextBlock Text="63" HorizontalAlignment="Center" FontSize="11" Opacity="0.7" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="1" Spacing="4" HorizontalAlignment="Stretch">
+                            <TextBlock Text="{Binding Band2}" HorizontalAlignment="Center" FontSize="12" />
+                            <Slider Orientation="Vertical" Height="180" HorizontalAlignment="Center"
+                                    Minimum="-10" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                    Value="{Binding Band2}" />
+                            <TextBlock Text="125" HorizontalAlignment="Center" FontSize="11" Opacity="0.7" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="2" Spacing="4" HorizontalAlignment="Stretch">
+                            <TextBlock Text="{Binding Band3}" HorizontalAlignment="Center" FontSize="12" />
+                            <Slider Orientation="Vertical" Height="180" HorizontalAlignment="Center"
+                                    Minimum="-10" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                    Value="{Binding Band3}" />
+                            <TextBlock Text="250" HorizontalAlignment="Center" FontSize="11" Opacity="0.7" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="3" Spacing="4" HorizontalAlignment="Stretch">
+                            <TextBlock Text="{Binding Band4}" HorizontalAlignment="Center" FontSize="12" />
+                            <Slider Orientation="Vertical" Height="180" HorizontalAlignment="Center"
+                                    Minimum="-10" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                    Value="{Binding Band4}" />
+                            <TextBlock Text="500" HorizontalAlignment="Center" FontSize="11" Opacity="0.7" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="4" Spacing="4" HorizontalAlignment="Stretch">
+                            <TextBlock Text="{Binding Band5}" HorizontalAlignment="Center" FontSize="12" />
+                            <Slider Orientation="Vertical" Height="180" HorizontalAlignment="Center"
+                                    Minimum="-10" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                    Value="{Binding Band5}" />
+                            <TextBlock Text="1k" HorizontalAlignment="Center" FontSize="11" Opacity="0.7" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="5" Spacing="4" HorizontalAlignment="Stretch">
+                            <TextBlock Text="{Binding Band6}" HorizontalAlignment="Center" FontSize="12" />
+                            <Slider Orientation="Vertical" Height="180" HorizontalAlignment="Center"
+                                    Minimum="-10" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                    Value="{Binding Band6}" />
+                            <TextBlock Text="2k" HorizontalAlignment="Center" FontSize="11" Opacity="0.7" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="6" Spacing="4" HorizontalAlignment="Stretch">
+                            <TextBlock Text="{Binding Band7}" HorizontalAlignment="Center" FontSize="12" />
+                            <Slider Orientation="Vertical" Height="180" HorizontalAlignment="Center"
+                                    Minimum="-10" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                    Value="{Binding Band7}" />
+                            <TextBlock Text="4k" HorizontalAlignment="Center" FontSize="11" Opacity="0.7" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="7" Spacing="4" HorizontalAlignment="Stretch">
+                            <TextBlock Text="{Binding Band8}" HorizontalAlignment="Center" FontSize="12" />
+                            <Slider Orientation="Vertical" Height="180" HorizontalAlignment="Center"
+                                    Minimum="-10" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                    Value="{Binding Band8}" />
+                            <TextBlock Text="8k" HorizontalAlignment="Center" FontSize="11" Opacity="0.7" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="8" Spacing="4" HorizontalAlignment="Stretch">
+                            <TextBlock Text="{Binding Band9}" HorizontalAlignment="Center" FontSize="12" />
+                            <Slider Orientation="Vertical" Height="180" HorizontalAlignment="Center"
+                                    Minimum="-10" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                    Value="{Binding Band9}" />
+                            <TextBlock Text="16k" HorizontalAlignment="Center" FontSize="11" Opacity="0.7" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
             </controls:SettingsGroup>
 
             <controls:SettingsGroup>

--- a/GalaxyBudsClient/Interface/Pages/EqualizerPage.axaml
+++ b/GalaxyBudsClient/Interface/Pages/EqualizerPage.axaml
@@ -44,6 +44,100 @@
 
             <controls:SettingsGroup>
                 <Interaction.Behaviors>
+                    <ext:RequiresFeatureBehavior Feature="CustomEqualizer" />
+                </Interaction.Behaviors>
+
+                <controls:SettingsSwitchItem
+                    Content="Custom equalizer"
+                    Description="Set your own 9-band curve instead of a preset (low to high frequency, -10 to +10)"
+                    Symbol="Options"
+                    IsChecked="{Binding IsCustomEqEnabled}" />
+
+                <controls:SettingsSliderItem
+                    Content="Band 1"
+                    Description="{Binding Band1}"
+                    Debounce="True"
+                    IconSource="{StaticResource IconPlaceholder}"
+                    IsEnabled="{Binding IsCustomEqEnabled}"
+                    Minimum="-10"
+                    Maximum="10"
+                    Value="{Binding Band1}" />
+                <controls:SettingsSliderItem
+                    Content="Band 2"
+                    Description="{Binding Band2}"
+                    Debounce="True"
+                    IconSource="{StaticResource IconPlaceholder}"
+                    IsEnabled="{Binding IsCustomEqEnabled}"
+                    Minimum="-10"
+                    Maximum="10"
+                    Value="{Binding Band2}" />
+                <controls:SettingsSliderItem
+                    Content="Band 3"
+                    Description="{Binding Band3}"
+                    Debounce="True"
+                    IconSource="{StaticResource IconPlaceholder}"
+                    IsEnabled="{Binding IsCustomEqEnabled}"
+                    Minimum="-10"
+                    Maximum="10"
+                    Value="{Binding Band3}" />
+                <controls:SettingsSliderItem
+                    Content="Band 4"
+                    Description="{Binding Band4}"
+                    Debounce="True"
+                    IconSource="{StaticResource IconPlaceholder}"
+                    IsEnabled="{Binding IsCustomEqEnabled}"
+                    Minimum="-10"
+                    Maximum="10"
+                    Value="{Binding Band4}" />
+                <controls:SettingsSliderItem
+                    Content="Band 5"
+                    Description="{Binding Band5}"
+                    Debounce="True"
+                    IconSource="{StaticResource IconPlaceholder}"
+                    IsEnabled="{Binding IsCustomEqEnabled}"
+                    Minimum="-10"
+                    Maximum="10"
+                    Value="{Binding Band5}" />
+                <controls:SettingsSliderItem
+                    Content="Band 6"
+                    Description="{Binding Band6}"
+                    Debounce="True"
+                    IconSource="{StaticResource IconPlaceholder}"
+                    IsEnabled="{Binding IsCustomEqEnabled}"
+                    Minimum="-10"
+                    Maximum="10"
+                    Value="{Binding Band6}" />
+                <controls:SettingsSliderItem
+                    Content="Band 7"
+                    Description="{Binding Band7}"
+                    Debounce="True"
+                    IconSource="{StaticResource IconPlaceholder}"
+                    IsEnabled="{Binding IsCustomEqEnabled}"
+                    Minimum="-10"
+                    Maximum="10"
+                    Value="{Binding Band7}" />
+                <controls:SettingsSliderItem
+                    Content="Band 8"
+                    Description="{Binding Band8}"
+                    Debounce="True"
+                    IconSource="{StaticResource IconPlaceholder}"
+                    IsEnabled="{Binding IsCustomEqEnabled}"
+                    Minimum="-10"
+                    Maximum="10"
+                    Value="{Binding Band8}" />
+                <controls:SettingsSliderItem
+                    Content="Band 9"
+                    Description="{Binding Band9}"
+                    Debounce="True"
+                    IconSource="{StaticResource IconPlaceholder}"
+                    IsEnabled="{Binding IsCustomEqEnabled}"
+                    Minimum="-10"
+                    Maximum="10"
+                    Value="{Binding Band9}" />
+            </controls:SettingsGroup>
+
+            <controls:SettingsGroup>
+                <Interaction.Behaviors>
                     <ext:RequiresFeatureBehavior Feature="StereoPan" />
                 </Interaction.Behaviors>
 

--- a/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
+++ b/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
@@ -15,6 +15,8 @@ using GalaxyBudsClient.Model.Constants;
 using GalaxyBudsClient.Model.Specifications;
 using GalaxyBudsClient.Platform;
 
+using Serilog;
+
 namespace GalaxyBudsClient.Interface.ViewModels.Pages;
 
 public partial class EqualizerPageViewModel : MainPageViewModelBase
@@ -154,16 +156,19 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
         }
     }
 
-    private static string[] BuildEqOptions(bool supportsCustom)
+    private static EqOption[] BuildEqOptions(bool supportsCustom)
     {
-        var options = new List<string>
+        var labels = new List<string>
         {
             EqOff, Strings.EqBass, Strings.EqSoft, Strings.EqDynamic, Strings.EqClear, Strings.EqTreble
         };
         if (supportsCustom)
             for (var slot = 1; slot <= CustomSlotCount; slot++)
-                options.Add($"Custom {slot}");
-        return options.ToArray();
+                labels.Add($"Custom {slot}");
+        var options = new EqOption[labels.Count];
+        for (var i = 0; i < labels.Count; i++)
+            options[i] = new EqOption(i, labels[i]);
+        return options;
     }
 
     private static int[][] CreateEmptySlots()
@@ -217,6 +222,9 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
 
     private async void OnPropertyChanged(object? sender, PropertyChangedEventArgs args)
     {
+        // async void: an unobserved exception from a BT send would crash the app — guard the handler.
+        try
+        {
         switch (args.PropertyName)
         {
             // The EQ dropdown (Off / presets / Custom) is the single user-facing control. Selecting
@@ -225,7 +233,7 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
             case nameof(SelectedEqOption):
                 if (_isSyncingEqOption)
                     break;
-                await ApplyEqOptionAsync(Array.IndexOf(EqOptions, SelectedEqOption));
+                await ApplyEqOptionAsync(SelectedEqOption?.Index ?? -1);
                 break;
             case nameof(EqPreset):
                 if (_isSyncingEqOption)
@@ -284,6 +292,7 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
                     break;
                 // The vertical sliders update per drag-tick; only send the settled values
                 _bandDebounce?.Cancel();
+                _bandDebounce?.Dispose();
                 _bandDebounce = new CancellationTokenSource();
                 try
                 {
@@ -298,6 +307,11 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
             case nameof(StereoBalance):
                 await BluetoothImpl.Instance.SendRequestAsync(MsgIds.SET_HEARING_ENHANCEMENTS, (byte)StereoBalance);
                 break;
+        }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Equalizer property-change handler failed");
         }
     }
 
@@ -339,6 +353,7 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
                 }
 
                 EqPreset = preset;
+                IsCustomEqEnabled = false;
             }
             else
             {
@@ -391,9 +406,17 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
     private const int FirstCustomOptionIndex = 6;
     private const int CustomSlotCount = 3;
 
-    [Reactive] private string[] _eqOptions = BuildEqOptions(false);
-    [Reactive] private string? _selectedEqOption;
+    [Reactive] private EqOption[] _eqOptions = BuildEqOptions(false);
+    [Reactive] private EqOption? _selectedEqOption;
     private bool _isSyncingEqOption;
+
+    // The dropdown items carry an explicit Index so selection is identified by index, not by the
+    // (possibly duplicated/empty in some locales) display string. Record value-equality makes the
+    // ComboBox's SelectedValue match the right item even if two labels were ever equal.
+    public sealed record EqOption(int Index, string Label)
+    {
+        public override string ToString() => Label;
+    }
     private int _activeCustomSlot;
     private int[][] _customSlots = CreateEmptySlots();
 

--- a/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
+++ b/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
@@ -14,6 +14,7 @@ using GalaxyBudsClient.Model;
 using GalaxyBudsClient.Model.Constants;
 using GalaxyBudsClient.Model.Specifications;
 using GalaxyBudsClient.Platform;
+using ReactiveUI;
 
 using Serilog;
 
@@ -115,14 +116,16 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
         }
         else
         {
+            // Persist BEFORE awaiting the send: a NoiseControlUpdate landing in the await
+            // window would otherwise re-push the still-flagged custom EQ over this preset.
+            // DON'T overwrite the saved slot curves — a non-custom (or transient startup)
+            // selection must never wipe stored custom EQs.
+            PersistCustomDisabled();
             await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder
             {
                 IsEnabled = option != OffOptionIndex,
                 Preset = EqPreset
             });
-            // Record that custom is no longer active, but DON'T overwrite the saved slot curves —
-            // a non-custom (or transient startup) selection must never wipe stored custom EQs.
-            PersistCustomDisabled();
         }
 
         EventDispatcher.Instance.Dispatch(Event.UpdateTrayIcon);
@@ -238,7 +241,11 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
             case nameof(EqPreset):
                 if (_isSyncingEqOption)
                     break;
-                IsCustomEqEnabled = false;
+                // Guard the flip: an unguarded set re-enters this handler and double-sends
+                _isSyncingEqOption = true;
+                try { IsCustomEqEnabled = false; }
+                finally { _isSyncingEqOption = false; }
+                PersistCustomDisabled();
                 await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder
                 {
                     IsEnabled = IsEqEnabled,
@@ -251,7 +258,13 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
                 if (_isSyncingEqOption)
                     break;
                 if (!IsEqEnabled)
-                    IsCustomEqEnabled = false;
+                {
+                    // Guarded flip: unguarded set re-enters this handler and double-sends
+                    _isSyncingEqOption = true;
+                    try { IsCustomEqEnabled = false; }
+                    finally { _isSyncingEqOption = false; }
+                    PersistCustomDisabled();
+                }
                 // When custom EQ just switched the EQ on, its own handler sends the messages
                 if (!(IsEqEnabled && IsCustomEqEnabled))
                 {
@@ -369,6 +382,17 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
 
             StereoBalance = e.HearingEnhancements;
         }
+
+        // SuppressChangeNotifications drops (not defers) PropertyChanged, so the band-slider
+        // enable state would go stale; re-raise under the sync guard so nothing re-sends.
+        _isSyncingEqOption = true;
+        try { this.RaisePropertyChanged(nameof(IsCustomEqEnabled)); }
+        finally { _isSyncingEqOption = false; }
+
+        // Phone-side preset changes arrive here without going through ApplyEqOptionAsync;
+        // keep the persisted re-push flag in sync so we don't override the phone's choice.
+        if (BluetoothImpl.Instance.Device.Current is { } dev)
+            dev.CustomEqualizerEnabled = IsCustomEqEnabled;
 
         // Load this device's saved custom slots so the dropdown can map to the active one
         LoadCustomSlotsFromDevice();

--- a/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
+++ b/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -22,6 +24,7 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
         SppMessageReceiver.Instance.ExtendedStatusUpdate += OnExtendedStatusUpdate;
         SppMessageReceiver.Instance.AnyMessageDecoded += OnAnyMessageDecoded;
         PropertyChanged += OnPropertyChanged;
+        SyncSelectedOption();
     }
 
     public override async void OnNavigatedTo()
@@ -33,19 +36,10 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
 
     private void OnAnyMessageDecoded(object? sender, BaseMessageDecoder decoder)
     {
-        if (decoder is not CustomEqualizerDataDecoder eq || eq.BandCount < 9)
-            return;
-
-        using var suppressor = SuppressChangeNotifications();
-        Band1 = eq.CustomBands[0];
-        Band2 = eq.CustomBands[1];
-        Band3 = eq.CustomBands[2];
-        Band4 = eq.CustomBands[3];
-        Band5 = eq.CustomBands[4];
-        Band6 = eq.CustomBands[5];
-        Band7 = eq.CustomBands[6];
-        Band8 = eq.CustomBands[7];
-        Band9 = eq.CustomBands[8];
+        // Custom EQ display is driven by the app's saved slots (see OnExtendedStatusUpdate and
+        // ApplyEqOptionAsync), not the firmware read-back. The Buds4 Pro's CUSTOM_EQUALIZE_RECV
+        // decode is unreliable (comes back flat) and would otherwise zero the sliders on launch,
+        // so the firmware read-back is intentionally ignored — the app is the source of truth.
     }
 
     private async Task SendCustomEqAsync()
@@ -64,22 +58,190 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
             IsEnabled = true,
             Preset = CustomEqPresetIndex
         });
+        SaveBandsToActiveSlot();
+        PersistCustomEq();
+    }
+
+    // Mirror the custom EQ state into the device's settings so it can be re-applied on the next
+    // connect — the firmware does not retain the custom band table across power cycles. The active
+    // slot's bands are also stored in CustomEqualizerBands so App.ReapplyCustomEqualizerAsync can
+    // re-push them without needing to know about slots.
+    private void PersistCustomEq()
+    {
+        var device = BluetoothImpl.Instance.Device.Current;
+        if (device == null)
+            return;
+
+        device.CustomEqualizerBands =
+            [Band1, Band2, Band3, Band4, Band5, Band6, Band7, Band8, Band9];
+        device.CustomEqualizerEnabled = IsCustomEqEnabled;
+        device.CustomEqualizerActiveSlot = _activeCustomSlot;
+        device.CustomEqualizerSlots = CloneSlots();
+    }
+
+    // Translate a dropdown selection into the underlying EQ state and push exactly one update.
+    // The state assignments run under _isSyncingEqOption so their own handlers don't re-send.
+    private async Task ApplyEqOptionAsync(int option)
+    {
+        if (option < 0)
+            return;
+
+        var isCustom = option >= FirstCustomOptionIndex;
+
+        _isSyncingEqOption = true;
+        try
+        {
+            IsEqEnabled = option != OffOptionIndex;
+            IsCustomEqEnabled = isCustom;
+            if (option is >= FirstPresetOptionIndex and <= LastPresetOptionIndex)
+                EqPreset = option - FirstPresetOptionIndex;
+            if (isCustom)
+            {
+                _activeCustomSlot = Math.Clamp(option - FirstCustomOptionIndex, 0, CustomSlotCount - 1);
+                // Move the band sliders to the selected slot's saved curve before pushing it
+                LoadActiveSlotIntoBands();
+            }
+        }
+        finally
+        {
+            _isSyncingEqOption = false;
+        }
+
+        if (isCustom)
+        {
+            await SendCustomEqAsync();
+        }
+        else
+        {
+            await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder
+            {
+                IsEnabled = option != OffOptionIndex,
+                Preset = EqPreset
+            });
+            // Record that custom is no longer active, but DON'T overwrite the saved slot curves —
+            // a non-custom (or transient startup) selection must never wipe stored custom EQs.
+            PersistCustomDisabled();
+        }
+
+        EventDispatcher.Instance.Dispatch(Event.UpdateTrayIcon);
+    }
+
+    // Mark custom EQ inactive without touching the persisted band/slot tables.
+    private static void PersistCustomDisabled()
+    {
+        var device = BluetoothImpl.Instance.Device.Current;
+        if (device != null)
+            device.CustomEqualizerEnabled = false;
+    }
+
+    // Project the underlying EQ state back onto the dropdown (used after tray hotkeys and device
+    // sync). Guarded so writing SelectedEqOption doesn't loop back into ApplyEqOptionAsync.
+    private void SyncSelectedOption()
+    {
+        _isSyncingEqOption = true;
+        try
+        {
+            var index = !IsEqEnabled
+                ? OffOptionIndex
+                : IsCustomEqEnabled
+                    ? FirstCustomOptionIndex + Math.Clamp(_activeCustomSlot, 0, CustomSlotCount - 1)
+                    : Math.Clamp(EqPreset + FirstPresetOptionIndex, FirstPresetOptionIndex, LastPresetOptionIndex);
+            SelectedEqOption = index < EqOptions.Length ? EqOptions[index] : EqOptions[OffOptionIndex];
+        }
+        finally
+        {
+            _isSyncingEqOption = false;
+        }
+    }
+
+    private static string[] BuildEqOptions(bool supportsCustom)
+    {
+        var options = new List<string>
+        {
+            EqOff, Strings.EqBass, Strings.EqSoft, Strings.EqDynamic, Strings.EqClear, Strings.EqTreble
+        };
+        if (supportsCustom)
+            for (var slot = 1; slot <= CustomSlotCount; slot++)
+                options.Add($"Custom {slot}");
+        return options.ToArray();
+    }
+
+    private static int[][] CreateEmptySlots()
+    {
+        var slots = new int[CustomSlotCount][];
+        for (var i = 0; i < CustomSlotCount; i++)
+            slots[i] = new int[9];
+        return slots;
+    }
+
+    private int[][] CloneSlots()
+    {
+        var copy = new int[CustomSlotCount][];
+        for (var i = 0; i < CustomSlotCount; i++)
+            copy[i] = (int[])_customSlots[i].Clone();
+        return copy;
+    }
+
+    private void LoadCustomSlotsFromDevice()
+    {
+        _customSlots = CreateEmptySlots();
+        _activeCustomSlot = 0;
+
+        var device = BluetoothImpl.Instance.Device.Current;
+        if (device == null)
+            return;
+
+        _activeCustomSlot = Math.Clamp(device.CustomEqualizerActiveSlot, 0, CustomSlotCount - 1);
+        var saved = device.CustomEqualizerSlots;
+        if (saved == null)
+            return;
+
+        for (var i = 0; i < CustomSlotCount && i < saved.Length; i++)
+            if (saved[i] is { Length: 9 })
+                _customSlots[i] = (int[])saved[i].Clone();
+    }
+
+    private void LoadActiveSlotIntoBands()
+    {
+        var bands = _customSlots[_activeCustomSlot];
+        Band1 = bands[0]; Band2 = bands[1]; Band3 = bands[2];
+        Band4 = bands[3]; Band5 = bands[4]; Band6 = bands[5];
+        Band7 = bands[6]; Band8 = bands[7]; Band9 = bands[8];
+    }
+
+    private void SaveBandsToActiveSlot()
+    {
+        _customSlots[_activeCustomSlot] =
+            [Band1, Band2, Band3, Band4, Band5, Band6, Band7, Band8, Band9];
     }
 
     private async void OnPropertyChanged(object? sender, PropertyChangedEventArgs args)
     {
         switch (args.PropertyName)
         {
+            // The EQ dropdown (Off / presets / Custom) is the single user-facing control. Selecting
+            // an entry drives the underlying IsEqEnabled / EqPreset / IsCustomEqEnabled state, which
+            // is also moved by tray hotkeys and device sync — see ApplyEqOptionAsync/SyncSelectedOption.
+            case nameof(SelectedEqOption):
+                if (_isSyncingEqOption)
+                    break;
+                await ApplyEqOptionAsync(Array.IndexOf(EqOptions, SelectedEqOption));
+                break;
             case nameof(EqPreset):
+                if (_isSyncingEqOption)
+                    break;
                 IsCustomEqEnabled = false;
                 await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder
                 {
                     IsEnabled = IsEqEnabled,
                     Preset = EqPreset
                 });
+                SyncSelectedOption();
                 EventDispatcher.Instance.Dispatch(Event.UpdateTrayIcon);
                 break;
             case nameof(IsEqEnabled):
+                if (_isSyncingEqOption)
+                    break;
                 if (!IsEqEnabled)
                     IsCustomEqEnabled = false;
                 // When custom EQ just switched the EQ on, its own handler sends the messages
@@ -91,9 +253,12 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
                         Preset = EqPreset
                     });
                 }
+                SyncSelectedOption();
                 EventDispatcher.Instance.Dispatch(Event.UpdateTrayIcon);
                 break;
             case nameof(IsCustomEqEnabled):
+                if (_isSyncingEqOption)
+                    break;
                 if (IsCustomEqEnabled)
                 {
                     IsEqEnabled = true;
@@ -106,12 +271,16 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
                         IsEnabled = IsEqEnabled,
                         Preset = EqPreset
                     });
+                    PersistCustomDisabled();
                 }
+                SyncSelectedOption();
                 break;
             case nameof(Band1) or nameof(Band2) or nameof(Band3) or
                 nameof(Band4) or nameof(Band5) or nameof(Band6) or
                 nameof(Band7) or nameof(Band8) or nameof(Band9):
-                if (!IsCustomEqEnabled)
+                // Loading a slot's curve into the sliders sets these under the sync guard; don't
+                // treat that programmatic change as a user edit to push back.
+                if (_isSyncingEqOption || !IsCustomEqEnabled)
                     break;
                 // The vertical sliders update per drag-tick; only send the settled values
                 _bandDebounce?.Cancel();
@@ -155,35 +324,53 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
 
     private void OnExtendedStatusUpdate(object? sender, ExtendedStatusUpdateDecoder e)
     {
-        using var suppressor = SuppressChangeNotifications();
-        
-        if (BluetoothImpl.Instance.CurrentModel == Models.Buds)
+        using (SuppressChangeNotifications())
         {
-            IsEqEnabled = e.EqualizerEnabled;
-				
-            var preset = e.EqualizerMode;
-            if (preset > MaximumEqPreset)
+            if (BluetoothImpl.Instance.CurrentModel == Models.Buds)
             {
-                /* 0 - 4: regular presets, 5 - 9: presets used when Dolby Atmos is enabled on the phone
-                   There is no audible difference. */
-                preset -= 5;
+                IsEqEnabled = e.EqualizerEnabled;
+
+                var preset = e.EqualizerMode;
+                if (preset > MaximumEqPreset)
+                {
+                    /* 0 - 4: regular presets, 5 - 9: presets used when Dolby Atmos is enabled on the phone
+                       There is no audible difference. */
+                    preset -= 5;
+                }
+
+                EqPreset = preset;
+            }
+            else
+            {
+                IsEqEnabled = e.EqualizerMode != 0;
+                IsCustomEqEnabled = e.EqualizerMode == CustomEqPresetIndex + 1;
+                // If EQ disabled, set to Dynamic (2) by default; keep the preset
+                // untouched while the custom preset is active (its index is out of range)
+                if (e.EqualizerMode == 0)
+                    EqPreset = 2;
+                else if (!IsCustomEqEnabled)
+                    EqPreset = e.EqualizerMode - 1;
             }
 
-            EqPreset = preset;
+            StereoBalance = e.HearingEnhancements;
         }
-        else
+
+        // Load this device's saved custom slots so the dropdown can map to the active one
+        LoadCustomSlotsFromDevice();
+
+        // If custom is active, show the saved active-slot curve in the sliders (guarded so it
+        // updates the UI without re-sending). The app's slots are authoritative, not the firmware.
+        if (IsCustomEqEnabled)
         {
-            IsEqEnabled = e.EqualizerMode != 0;
-            IsCustomEqEnabled = e.EqualizerMode == CustomEqPresetIndex + 1;
-            // If EQ disabled, set to Dynamic (2) by default; keep the preset slider
-            // untouched while the custom preset is active (its index is out of range)
-            if (e.EqualizerMode == 0)
-                EqPreset = 2;
-            else if (!IsCustomEqEnabled)
-                EqPreset = e.EqualizerMode - 1;
+            _isSyncingEqOption = true;
+            try { LoadActiveSlotIntoBands(); }
+            finally { _isSyncingEqOption = false; }
         }
-        
-        StereoBalance = e.HearingEnhancements;
+
+        // Only offer the Custom entries on devices whose firmware supports it, then reflect the
+        // device's current EQ state in the dropdown without re-sending it.
+        EqOptions = BuildEqOptions(BluetoothImpl.Instance.DeviceSpec.Supports(Features.CustomEqualizer));
+        SyncSelectedOption();
     }
 
     public override Control CreateView() => new EqualizerPage { DataContext = this };
@@ -192,6 +379,23 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
     [Reactive] private int _eqPreset;
     [Reactive] private int _stereoBalance;
     private CancellationTokenSource? _bandDebounce;
+
+    // Single EQ dropdown: index 0 = Off, 1..5 = presets (Bass/Soft/Dynamic/Clear/Treble),
+    // 6.. = Custom slots (only present when the device supports custom EQ). The firmware has a
+    // single custom band table, so the slots are stored app-side and the selected one is pushed
+    // into that single table.
+    private const string EqOff = "Off";
+    private const int OffOptionIndex = 0;
+    private const int FirstPresetOptionIndex = 1;
+    private const int LastPresetOptionIndex = 5;
+    private const int FirstCustomOptionIndex = 6;
+    private const int CustomSlotCount = 3;
+
+    [Reactive] private string[] _eqOptions = BuildEqOptions(false);
+    [Reactive] private string? _selectedEqOption;
+    private bool _isSyncingEqOption;
+    private int _activeCustomSlot;
+    private int[][] _customSlots = CreateEmptySlots();
 
     [Reactive] private bool _isCustomEqEnabled;
     [Reactive] private int _band1;

--- a/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
+++ b/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using FluentIcons.Common;
@@ -69,13 +70,27 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
     {
         switch (args.PropertyName)
         {
-            case nameof(IsEqEnabled) or nameof(EqPreset):
+            case nameof(EqPreset):
                 IsCustomEqEnabled = false;
                 await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder
                 {
                     IsEnabled = IsEqEnabled,
                     Preset = EqPreset
                 });
+                EventDispatcher.Instance.Dispatch(Event.UpdateTrayIcon);
+                break;
+            case nameof(IsEqEnabled):
+                if (!IsEqEnabled)
+                    IsCustomEqEnabled = false;
+                // When custom EQ just switched the EQ on, its own handler sends the messages
+                if (!(IsEqEnabled && IsCustomEqEnabled))
+                {
+                    await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder
+                    {
+                        IsEnabled = IsEqEnabled,
+                        Preset = EqPreset
+                    });
+                }
                 EventDispatcher.Instance.Dispatch(Event.UpdateTrayIcon);
                 break;
             case nameof(IsCustomEqEnabled):
@@ -96,8 +111,20 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
             case nameof(Band1) or nameof(Band2) or nameof(Band3) or
                 nameof(Band4) or nameof(Band5) or nameof(Band6) or
                 nameof(Band7) or nameof(Band8) or nameof(Band9):
-                if (IsCustomEqEnabled)
-                    await SendCustomEqAsync();
+                if (!IsCustomEqEnabled)
+                    break;
+                // The vertical sliders update per drag-tick; only send the settled values
+                _bandDebounce?.Cancel();
+                _bandDebounce = new CancellationTokenSource();
+                try
+                {
+                    await Task.Delay(250, _bandDebounce.Token);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
+                await SendCustomEqAsync();
                 break;
             case nameof(StereoBalance):
                 await BluetoothImpl.Instance.SendRequestAsync(MsgIds.SET_HEARING_ENHANCEMENTS, (byte)StereoBalance);
@@ -164,6 +191,8 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
     [Reactive] private bool _isEqEnabled;
     [Reactive] private int _eqPreset;
     [Reactive] private int _stereoBalance;
+    private CancellationTokenSource? _bandDebounce;
+
     [Reactive] private bool _isCustomEqEnabled;
     [Reactive] private int _band1;
     [Reactive] private int _band2;

--- a/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
+++ b/GalaxyBudsClient/Interface/ViewModels/Pages/EqualizerPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using FluentIcons.Common;
 using GalaxyBudsClient.Generated.I18N;
@@ -8,6 +9,7 @@ using GalaxyBudsClient.Message.Decoder;
 using GalaxyBudsClient.Message.Encoder;
 using GalaxyBudsClient.Model;
 using GalaxyBudsClient.Model.Constants;
+using GalaxyBudsClient.Model.Specifications;
 using GalaxyBudsClient.Platform;
 
 namespace GalaxyBudsClient.Interface.ViewModels.Pages;
@@ -17,7 +19,50 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
     public EqualizerPageViewModel()
     {
         SppMessageReceiver.Instance.ExtendedStatusUpdate += OnExtendedStatusUpdate;
+        SppMessageReceiver.Instance.AnyMessageDecoded += OnAnyMessageDecoded;
         PropertyChanged += OnPropertyChanged;
+    }
+
+    public override async void OnNavigatedTo()
+    {
+        // Ask the device for its stored custom EQ band values
+        if (BluetoothImpl.Instance.DeviceSpec.Supports(Features.CustomEqualizer))
+            await BluetoothImpl.Instance.SendRequestAsync(MsgIds.CUSTOM_EQUALIZE_RECV);
+    }
+
+    private void OnAnyMessageDecoded(object? sender, BaseMessageDecoder decoder)
+    {
+        if (decoder is not CustomEqualizerDataDecoder eq || eq.BandCount < 9)
+            return;
+
+        using var suppressor = SuppressChangeNotifications();
+        Band1 = eq.CustomBands[0];
+        Band2 = eq.CustomBands[1];
+        Band3 = eq.CustomBands[2];
+        Band4 = eq.CustomBands[3];
+        Band5 = eq.CustomBands[4];
+        Band6 = eq.CustomBands[5];
+        Band7 = eq.CustomBands[6];
+        Band8 = eq.CustomBands[7];
+        Band9 = eq.CustomBands[8];
+    }
+
+    private async Task SendCustomEqAsync()
+    {
+        await BluetoothImpl.Instance.SendAsync(new SetCustomEqualizerEncoder
+        {
+            BandGains =
+            [
+                (sbyte)Band1, (sbyte)Band2, (sbyte)Band3,
+                (sbyte)Band4, (sbyte)Band5, (sbyte)Band6,
+                (sbyte)Band7, (sbyte)Band8, (sbyte)Band9
+            ]
+        });
+        await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder
+        {
+            IsEnabled = true,
+            Preset = CustomEqPresetIndex
+        });
     }
 
     private async void OnPropertyChanged(object? sender, PropertyChangedEventArgs args)
@@ -25,12 +70,34 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
         switch (args.PropertyName)
         {
             case nameof(IsEqEnabled) or nameof(EqPreset):
+                IsCustomEqEnabled = false;
                 await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder
                 {
                     IsEnabled = IsEqEnabled,
                     Preset = EqPreset
                 });
                 EventDispatcher.Instance.Dispatch(Event.UpdateTrayIcon);
+                break;
+            case nameof(IsCustomEqEnabled):
+                if (IsCustomEqEnabled)
+                {
+                    IsEqEnabled = true;
+                    await SendCustomEqAsync();
+                }
+                else
+                {
+                    await BluetoothImpl.Instance.SendAsync(new SetEqualizerEncoder
+                    {
+                        IsEnabled = IsEqEnabled,
+                        Preset = EqPreset
+                    });
+                }
+                break;
+            case nameof(Band1) or nameof(Band2) or nameof(Band3) or
+                nameof(Band4) or nameof(Band5) or nameof(Band6) or
+                nameof(Band7) or nameof(Band8) or nameof(Band9):
+                if (IsCustomEqEnabled)
+                    await SendCustomEqAsync();
                 break;
             case nameof(StereoBalance):
                 await BluetoothImpl.Instance.SendRequestAsync(MsgIds.SET_HEARING_ENHANCEMENTS, (byte)StereoBalance);
@@ -80,8 +147,13 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
         else
         {
             IsEqEnabled = e.EqualizerMode != 0;
-            // If EQ disabled, set to Dynamic (2) by default
-            EqPreset = e.EqualizerMode == 0 ? 2 : e.EqualizerMode - 1;
+            IsCustomEqEnabled = e.EqualizerMode == CustomEqPresetIndex + 1;
+            // If EQ disabled, set to Dynamic (2) by default; keep the preset slider
+            // untouched while the custom preset is active (its index is out of range)
+            if (e.EqualizerMode == 0)
+                EqPreset = 2;
+            else if (!IsCustomEqEnabled)
+                EqPreset = e.EqualizerMode - 1;
         }
         
         StereoBalance = e.HearingEnhancements;
@@ -92,8 +164,20 @@ public partial class EqualizerPageViewModel : MainPageViewModelBase
     [Reactive] private bool _isEqEnabled;
     [Reactive] private int _eqPreset;
     [Reactive] private int _stereoBalance;
+    [Reactive] private bool _isCustomEqEnabled;
+    [Reactive] private int _band1;
+    [Reactive] private int _band2;
+    [Reactive] private int _band3;
+    [Reactive] private int _band4;
+    [Reactive] private int _band5;
+    [Reactive] private int _band6;
+    [Reactive] private int _band7;
+    [Reactive] private int _band8;
+    [Reactive] private int _band9;
 
     public int MaximumEqPreset => 4;
+    // Samsung preset index 6 = custom; the EQUALIZER message carries index + 1 (7)
+    public int CustomEqPresetIndex => 6;
     public override string TitleKey => Keys.EqHeader;
     public override Symbol IconKey => Symbol.DeviceEq;
     public override bool ShowsInFooter => false;

--- a/GalaxyBudsClient/Message/Decoder/CustomEqualizerDataDecoder.cs
+++ b/GalaxyBudsClient/Message/Decoder/CustomEqualizerDataDecoder.cs
@@ -1,0 +1,29 @@
+using GalaxyBudsClient.Generated.Model.Attributes;
+
+namespace GalaxyBudsClient.Message.Decoder;
+
+/*
+ * Response to a CUSTOM_EQUALIZE_RECV query.
+ * Payload: [presetCount][bandCount][(presetCount - 1) * bandCount preset table][bandCount custom band gains]
+ * The flat first preset is omitted from the table on the wire.
+ */
+[MessageDecoder(MsgIds.CUSTOM_EQUALIZE_RECV)]
+internal class CustomEqualizerDataDecoder : BaseMessageDecoder
+{
+    public int PresetCount { get; }
+    public int BandCount { get; }
+    public sbyte[] CustomBands { get; }
+
+    public CustomEqualizerDataDecoder(SppMessage msg) : base(msg)
+    {
+        PresetCount = msg.Payload.Length > 0 ? msg.Payload[0] : 0;
+        BandCount = msg.Payload.Length > 1 ? msg.Payload[1] : 0;
+        CustomBands = new sbyte[BandCount];
+
+        var offset = 2 + (PresetCount - 1) * BandCount;
+        for (var i = 0; i < BandCount && offset + i < msg.Payload.Length; i++)
+        {
+            CustomBands[i] = (sbyte)msg.Payload[offset + i];
+        }
+    }
+}

--- a/GalaxyBudsClient/Message/Decoder/CustomEqualizerDataDecoder.cs
+++ b/GalaxyBudsClient/Message/Decoder/CustomEqualizerDataDecoder.cs
@@ -21,6 +21,8 @@ internal class CustomEqualizerDataDecoder : BaseMessageDecoder
         CustomBands = new sbyte[BandCount];
 
         var offset = 2 + (PresetCount - 1) * BandCount;
+        if (PresetCount < 1 || offset < 2 || offset + BandCount > msg.Payload.Length)
+            return;
         for (var i = 0; i < BandCount && offset + i < msg.Payload.Length; i++)
         {
             CustomBands[i] = (sbyte)msg.Payload[offset + i];

--- a/GalaxyBudsClient/Message/Encoder/SetCustomEqualizerEncoder.cs
+++ b/GalaxyBudsClient/Message/Encoder/SetCustomEqualizerEncoder.cs
@@ -1,0 +1,25 @@
+using GalaxyBudsClient.Generated.Model.Attributes;
+
+namespace GalaxyBudsClient.Message.Encoder;
+
+/*
+ * Payload: [bandCount][bandCount signed band gains], gains range from -10 to +10.
+ * Applies only while the custom preset is selected via the EQUALIZER message.
+ */
+[MessageEncoder(MsgIds.CUSTOM_EQUALIZE_SEND)]
+public class SetCustomEqualizerEncoder : BaseMessageEncoder
+{
+    public sbyte[] BandGains { get; init; } = new sbyte[9];
+
+    public override SppMessage Encode()
+    {
+        var payload = new byte[BandGains.Length + 1];
+        payload[0] = (byte)BandGains.Length;
+        for (var i = 0; i < BandGains.Length; i++)
+        {
+            payload[i + 1] = (byte)BandGains[i];
+        }
+
+        return new SppMessage(MsgIds.CUSTOM_EQUALIZE_SEND, MsgTypes.Request, payload);
+    }
+}

--- a/GalaxyBudsClient/Model/Config/Settings.cs
+++ b/GalaxyBudsClient/Model/Config/Settings.cs
@@ -38,6 +38,14 @@ public static class Settings
         Data.ExperimentsFinishedIds.CollectionChanged += (_, _) => Save();
         Data.CustomActionLeft.PropertyChanged += OnTouchActionPropertyChanged;
         Data.CustomActionRight.PropertyChanged += OnTouchActionPropertyChanged;
+
+        // CollectionChanged only subscribes devices/hotkeys added AFTER load. Items deserialized
+        // from disk are already in the collection, so without this they never trigger a save when
+        // their properties change — which is why per-device settings (e.g. custom EQ) never persisted.
+        foreach (var device in Data.Devices)
+            device.PropertyChanged += OnDevicePropertyChanged;
+        foreach (var hotkey in Data.Hotkeys)
+            hotkey.PropertyChanged += OnHotkeyPropertyChanged;
     }
     
     public static Themes DefaultTheme => PlatformUtils.SupportsMicaTheme ? Themes.DarkMica : 

--- a/GalaxyBudsClient/Model/Config/SettingsData.cs
+++ b/GalaxyBudsClient/Model/Config/SettingsData.cs
@@ -28,6 +28,15 @@ public class Device : ReactiveObject
     [ReactiveUI.Fody.Helpers.Reactive] public string MacAddress { set; get; } = string.Empty;
     [ReactiveUI.Fody.Helpers.Reactive] public string Name { set; get; } = string.Empty;
     [ReactiveUI.Fody.Helpers.Reactive] public DeviceIds? DeviceColor { set; get; }
+
+    // Custom EQ band table is not retained by the firmware across power cycles, so persist it
+    // here and re-apply on connect (see App.OnExtendedStatusUpdate). CustomEqualizerBands holds the
+    // currently-active slot's curve (what gets re-pushed). The firmware has only one custom table,
+    // so multiple "Custom" slots are stored app-side here and the active one is pushed on selection.
+    [ReactiveUI.Fody.Helpers.Reactive] public bool CustomEqualizerEnabled { set; get; }
+    [ReactiveUI.Fody.Helpers.Reactive] public int[]? CustomEqualizerBands { set; get; }
+    [ReactiveUI.Fody.Helpers.Reactive] public int CustomEqualizerActiveSlot { set; get; }
+    [ReactiveUI.Fody.Helpers.Reactive] public int[][]? CustomEqualizerSlots { set; get; }
 }
     
 /*

--- a/GalaxyBudsClient/Model/Specifications/Buds3DeviceSpec.cs
+++ b/GalaxyBudsClient/Model/Specifications/Buds3DeviceSpec.cs
@@ -12,6 +12,8 @@ public class Buds3DeviceSpec : IDeviceSpec
     {
         { Features.SeamlessConnection, null },
         { Features.StereoPan, null},
+        // 9-band custom EQ: Buds3-generation feature (research-confirmed via Galaxy Wearable)
+        { Features.CustomEqualizer, null },
         { Features.FirmwareUpdates, null },
         { Features.NoiseControl, null },
         { Features.AmbientSound, null },

--- a/GalaxyBudsClient/Model/Specifications/Buds3FeDeviceSpec.cs
+++ b/GalaxyBudsClient/Model/Specifications/Buds3FeDeviceSpec.cs
@@ -12,6 +12,8 @@ public class Buds3FeDeviceSpec : IDeviceSpec
     {
         { Features.SeamlessConnection, null },
         { Features.StereoPan, null },
+        // 9-band custom EQ: Buds3-generation feature (research-confirmed via Galaxy Wearable)
+        { Features.CustomEqualizer, null },
         { Features.DoubleTapVolume, null },
         { Features.FirmwareUpdates, null },
         { Features.NoiseControl, null },

--- a/GalaxyBudsClient/Model/Specifications/Buds3ProDeviceSpec.cs
+++ b/GalaxyBudsClient/Model/Specifications/Buds3ProDeviceSpec.cs
@@ -12,6 +12,8 @@ public class Buds3ProDeviceSpec : IDeviceSpec
     {
         { Features.SeamlessConnection, null },
         { Features.StereoPan, null },
+        // 9-band custom EQ: Buds3-generation feature (research-confirmed via Galaxy Wearable)
+        { Features.CustomEqualizer, null },
         { Features.DoubleTapVolume, null },
         { Features.FirmwareUpdates, null },
         { Features.DetectConversations, null },

--- a/GalaxyBudsClient/Model/Specifications/Buds4DeviceSpec.cs
+++ b/GalaxyBudsClient/Model/Specifications/Buds4DeviceSpec.cs
@@ -12,6 +12,8 @@ public class Buds4DeviceSpec : IDeviceSpec
     {
         { Features.SeamlessConnection, null },
         { Features.StereoPan, null},
+        // 9-band custom EQ: Buds3-generation feature (research-confirmed via Galaxy Wearable)
+        { Features.CustomEqualizer, null },
         { Features.FirmwareUpdates, null },
         { Features.NoiseControl, null },
         { Features.AmbientSound, null },

--- a/GalaxyBudsClient/Model/Specifications/Buds4ProDeviceSpec.cs
+++ b/GalaxyBudsClient/Model/Specifications/Buds4ProDeviceSpec.cs
@@ -12,7 +12,7 @@ public class Buds4ProDeviceSpec : IDeviceSpec
     {
         { Features.SeamlessConnection, null },
         { Features.StereoPan, null },
-        { Features.DoubleTapVolume, null },
+        // DoubleTapVolume ("double-tap earbud edge") confirmed unsupported on Buds4 Pro (2026-06-21)
         { Features.FirmwareUpdates, null },
         { Features.DetectConversations, null },
         { Features.NoiseControl, null },

--- a/GalaxyBudsClient/Model/Specifications/Buds4ProDeviceSpec.cs
+++ b/GalaxyBudsClient/Model/Specifications/Buds4ProDeviceSpec.cs
@@ -26,6 +26,8 @@ public class Buds4ProDeviceSpec : IDeviceSpec
         { Features.ExtraClearCallSound, null },
         { Features.AmbientExtraLoud, null },
         { Features.AmbientSound, null },
+        { Features.AmbientSoundVolume, null },
+        { Features.CustomEqualizer, null },
         { Features.Anc, null },
         { Features.AmbientSidetone, null },
         { Features.AmbientCustomize, null },
@@ -60,7 +62,7 @@ public class Buds4ProDeviceSpec : IDeviceSpec
     );
         
     public string IconResourceKey => "Pro";
-    public int MaximumAmbientVolume => 2;
+    public int MaximumAmbientVolume => 4;
     public byte StartOfMessage => (byte)MsgConstants.Som;
     public byte EndOfMessage => (byte)MsgConstants.Eom;
 }

--- a/GalaxyBudsClient/Model/Specifications/Buds4ProDeviceSpec.cs
+++ b/GalaxyBudsClient/Model/Specifications/Buds4ProDeviceSpec.cs
@@ -24,7 +24,6 @@ public class Buds4ProDeviceSpec : IDeviceSpec
         { Features.BixbyWakeup, null },
         { Features.GearFitTest, null },
         { Features.ExtraClearCallSound, null },
-        { Features.AmbientExtraLoud, null },
         { Features.AmbientSound, null },
         { Features.AmbientSoundVolume, null },
         { Features.CustomEqualizer, null },

--- a/GalaxyBudsClient/Model/Specifications/Features.cs
+++ b/GalaxyBudsClient/Model/Specifications/Features.cs
@@ -51,4 +51,5 @@ public enum Features
     UsageReport,
     HotCommandLanguageUpdate,
     HiddenAtMode,
+    CustomEqualizer,
 }

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -38,7 +38,17 @@ one feature flag that the Buds4 Pro does not actually support (see below).
   its custom table on power-cycle). The Buds4 Pro custom-table read-back is unreliable
   (returns flat), so it is intentionally ignored to avoid zeroing the sliders.
 - The dropdown two-way syncs with tray hotkeys and device state via a re-entrancy guard.
-- "Custom" entries only appear on devices whose firmware reports custom-EQ support.
+- "Custom" entries only appear on devices whose spec declares `Features.CustomEqualizer`.
+
+**Custom-EQ model coverage (research-based).** Samsung introduced the 9-band custom EQ
+with the **Buds3 generation** (mid-2024); every pre-Buds3 model is presets-only. Upstream
+GalaxyBudsClient never implemented custom EQ (the `CUSTOM_EQUALIZE_*` message IDs were
+unused placeholders), so the per-model decision is driven by documented Samsung capability.
+`Features.CustomEqualizer` is therefore enabled on: **Buds3, Buds3 Pro, Buds3 FE, Buds4,
+Buds4 Pro**. It is left **off** for all pre-Buds3 models (Buds, Buds+, Buds Live, Buds Pro,
+Buds2, Buds2 Pro, Buds FE) and Buds Core, which expose only the 6 presets. Caveat: only the
+**Buds4 Pro** is hardware-verified; the other four share the same Galaxy Wearable 9-band EQ
+and protocol generation, so support is inferred from documentation, not bench-tested.
 
 ### 3. Settings persistence fix (root cause of per-device settings not saving)
 - `Settings` only subscribed devices/hotkeys **added during a session** to its

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,127 @@
+# Galaxy Buds4 Pro support + macOS stability & Developer Tools improvements
+
+Branch: `buds4pro-ambient-volume`
+
+## Summary
+
+Adds first-class support for the **Galaxy Buds4 Pro** (ambient volume control and a
+custom 9-band equalizer) and, along the way, fixes several macOS-specific stability
+issues and reworks the Developer Tools UI. The equalizer page was redesigned around a
+single dropdown with multiple app-side custom slots, and a long-standing settings-save
+bug that prevented per-device settings from persisting was fixed.
+
+All changes are additive or macOS-scoped; no existing device behavior is removed except
+one feature flag that the Buds4 Pro does not actually support (see below).
+
+---
+
+## Changes
+
+### 1. Buds4 Pro device support
+- New `Buds4ProDeviceSpec` feature wiring for ambient volume and custom EQ.
+- Ambient sound volume control (0–N levels) with a localization-aware strength converter
+  (`AmbientStrengthConverter`, `AmbientCustomizePage`).
+- Custom EQ encode/decode support: `SetCustomEqualizerEncoder`,
+  `CustomEqualizerDataDecoder`, and a new `Features.CustomEqualizer` flag.
+- Fixed a nil-string crash hit during Buds4 Pro pairing/identification.
+
+### 2. Equalizer redesign + multi-slot custom EQ
+- Replaced the separate **EQ on/off switch + preset slider + custom toggle** with a
+  single dropdown: **Off · Bass boost · Soft · Dynamic · Clear · Treble boost ·
+  Custom 1 · Custom 2 · Custom 3**.
+- The 9 band sliders are disabled unless a **Custom** slot is selected.
+- The firmware exposes only **one** custom EQ table, so the three custom slots are stored
+  **app-side, per device**. Selecting a slot pushes its curve to the single firmware table;
+  editing the sliders saves back to the active slot.
+- **The app's saved slots are the source of truth** for the custom curve. On connect the
+  active slot is loaded into the sliders and re-pushed to the firmware (the firmware drops
+  its custom table on power-cycle). The Buds4 Pro custom-table read-back is unreliable
+  (returns flat), so it is intentionally ignored to avoid zeroing the sliders.
+- The dropdown two-way syncs with tray hotkeys and device state via a re-entrancy guard.
+- "Custom" entries only appear on devices whose firmware reports custom-EQ support.
+
+### 3. Settings persistence fix (root cause of per-device settings not saving)
+- `Settings` only subscribed devices/hotkeys **added during a session** to its
+  save-on-change trigger. Items **deserialized from disk at startup** were already in the
+  collection and never got subscribed, so any change to a saved device's properties never
+  triggered a save (global settings/touch actions were unaffected — wired separately).
+- Fix: after load, subscribe every existing device and hotkey to the save trigger.
+- This is what made custom EQ (and any future per-device setting) actually persist.
+
+### 4. macOS native Bluetooth stability
+- Fixed a send/disconnect race, a disconnect-notification leak, and serialized outgoing
+  sends in the native macOS Bluetooth layer
+  (`BluetoothService.cs`, `Native/src/Bluetooth.mm`, `Native/src/BluetoothDeviceWatcher.mm`).
+
+### 5. macOS app behavior
+- **Crash fix:** the macOS accessibility bridge could raise an unguarded
+  `NullReferenceException` in FluentAvalonia's `ItemsRepeaterAutomationPeer.GetChildrenCore()`
+  while walking the automation tree (e.g. during a relayout), which propagated out of the
+  dispatcher loop and killed the app. A `Dispatcher.UnhandledException` handler now marks
+  **only** automation-peer exceptions as handled (logged); all other exceptions still
+  crash/report as before. (Upstream's latest has the same unguarded code, so this can't be
+  fixed by a FluentAvalonia bump.)
+- **Window on launch:** the macOS startup path detached the main window and started
+  menu-bar-only. It now shows the main window on launch (unless `/StartMinimized`) and
+  restores the dock icon, while keeping the menu-bar item.
+
+### 6. Developer Tools
+- Searchable, alphabetically-sorted message-ID picker (`AutoCompleteBox`) with an explicit
+  open button.
+- Message-ID suggestions dropdown pinned to a fixed width (was auto-growing to the longest
+  ID), with a smaller list font and tighter rows.
+- Smaller `DataGrid` fonts and row heights for the message/property logs; wider default
+  window (940×680).
+- Request/Response selector now defaults to **Request** instead of requiring a pick.
+- Fixed the 4-pane layout breaking on splitter drag.
+
+### 7. Removed
+- `Features.DoubleTapVolume` ("double-tap earbud edge") removed from `Buds4ProDeviceSpec` —
+  empirically confirmed unsupported on the Buds4 Pro. `RequiresFeatureBehavior` now hides
+  the toggle on this device.
+
+---
+
+## Files changed
+
+| Area | Files |
+|---|---|
+| Buds4 Pro spec / features | `Model/Specifications/Buds4ProDeviceSpec.cs`, `Model/Specifications/Features.cs` |
+| Equalizer | `Interface/Pages/EqualizerPage.axaml`, `Interface/ViewModels/Pages/EqualizerPageViewModel.cs`, `Message/Encoder/SetCustomEqualizerEncoder.cs`, `Message/Decoder/CustomEqualizerDataDecoder.cs` |
+| Ambient | `Interface/Pages/AmbientCustomizePage.axaml`, `Interface/Converters/AmbientStrengthConverter.cs` |
+| Settings persistence | `Model/Config/Settings.cs`, `Model/Config/SettingsData.cs` |
+| macOS app | `App.axaml.cs` |
+| macOS native BT | `GalaxyBudsClient.Platform.OSX/BluetoothService.cs`, `.../Native/src/Bluetooth.mm`, `.../Native/src/BluetoothDeviceWatcher.mm` |
+| Developer Tools | `Interface/Developer/DevTools.axaml`, `Interface/Developer/DevToolsView.axaml`, `Interface/Developer/DevToolsView.axaml.cs` |
+
+---
+
+## Testing
+
+Built and run on macOS (Apple Silicon, `net10.0-macos`, `osx-arm64`, Release) against a
+real Galaxy Buds4 Pro:
+- Ambient volume control works.
+- Custom EQ: setting a curve, switching between Custom 1/2/3, and the curve persisting
+  across app quit/relaunch — verified on disk in `settings.json` and reloaded into the
+  sliders on launch.
+- App no longer crashes when interacting with the EQ page.
+- Window opens on launch; menu-bar item retained.
+- Developer Tools dropdown sizing/fonts and default selections confirmed.
+
+## Known issues / follow-ups
+
+- **"Sharpen call sound" reverts to Off.** The toggle *writes* correctly
+  (`EXTRA_CLEAR_SOUND_CALL`), but the read-back (`ExtraClearCallSound`) is a tail field of
+  the Buds4 Pro `EXTENDED_STATUS_UPDATED` frame whose offset appears misaligned, so every
+  status update resets the toggle. Needs a captured id-65 frame to correct the offset
+  without disturbing adjacent fields (e.g. `CallPathControl`). Deliberately **not**
+  guessed at in this PR.
+- Factory-preset curves can't be shown on the (greyed) sliders: presets are applied
+  firmware-side by index and their per-band values are never transmitted. Only possible as
+  hardcoded cosmetic approximations.
+
+## Notes for reviewers
+
+- The committed build artifact `bin_osxarm64/Galaxy Buds Manager-5.2.1.0.pkg` (~92 MB)
+  should likely be removed from the branch / gitignored before merge — it's a generated
+  installer, not source.


### PR DESCRIPTION
## Summary

Adds Galaxy Buds4 Pro support improvements developed and tested on macOS against real hardware:

- **Ambient sound volume 0–4**: Buds4 Pro reports a 5-step ambient scale; the shared strength converter now selects a 5-step "Level 1–5" scale for Buds4 Pro only, while all other models keep their existing localized labels (`AsScaleLow/Moderate/High/Extraloud`, legacy 5-step scale for the original Buds).
- **9-band custom EQ with 3 save slots**: custom EQ dropdown entries, per-device persisted band tables, and re-push of the saved custom EQ on reconnect. The Buds4 Pro firmware drops the custom band table on power-cycle and on every noise-control switch, so the app re-pushes it once per connect and on `NOISE_CONTROLS` updates (gated to Buds4 Pro so other models' phone-side EQ choices are never overridden), mirroring Galaxy Wearable behavior.
- **macOS native Bluetooth layer hardening** (`Bluetooth.mm` / `BluetoothDeviceWatcher.mm`): ARC lifetime and teardown fixes, deduplicated Disconnected signaling, and a fix for a send-path race where a stale channel snapshot could tear down a fresh reconnection.

## Review pass

The branch went through a multi-agent adversarial review; all fixes verified:
- EQ state machine: guarded re-entrant `IsCustomEqEnabled` flips (no more duplicate EQUALIZER sends from tray hotkeys), persist-before-send ordering so a noise-control update landing mid-send can't re-push custom EQ over a freshly picked preset, and correct band-slider enable state after suppressed `ExtendedStatusUpdate` notifications.
- App subscribes its `ExtendedStatusUpdate` handler before page viewmodels so the connect-time EQ reapply reads persisted state deterministically.
- `CustomEqualizerDataDecoder`: bounds check on the computed preset-table offset (malformed payload could previously compute a negative offset).
- Dev tools: message ID is parsed from the AutoCompleteBox text, so typed IDs work and edited text can't silently send a stale selection.

Merged with current `master` (includes #718).

Co-authored with Claude (Claude Fable 5 <noreply@anthropic.com>).

🤖 Generated with [Claude Code](https://claude.com/claude-code)