### PR TITLE
Enable multipoint coexistence without a Samsung account

### DIFF
--- a/GalaxyBudsClient/App.axaml.cs
+++ b/GalaxyBudsClient/App.axaml.cs
@@ -94,6 +94,9 @@ public class App : Application
     
     public override void OnFrameworkInitializationCompleted()
     {
+        /* Must subscribe before the initial connection attempt to catch its Connected event */
+        MultipointPatcher.Init();
+
         if (BluetoothImpl.HasValidDevice)
         {
             Task.Run(() => BluetoothImpl.Instance.ConnectAsync());

--- a/GalaxyBudsClient/Interface/Pages/SettingsPage.axaml
+++ b/GalaxyBudsClient/Interface/Pages/SettingsPage.axaml
@@ -204,6 +204,27 @@
             </ui:SettingsExpander>
 
 
+            <ui:SettingsExpander Header="{ext:Translate {x:Static i18N:Keys.SettingsMultipointHeader}}"
+                                 IsVisible="{Binding IsMultipointSupported}">
+                <ui:SettingsExpander.IconSource>
+                    <ic:SymbolIconSource Symbol="LinkMultiple" />
+                </ui:SettingsExpander.IconSource>
+
+                <controls:SettingsSwitchItem
+                    Content="{ext:Translate {x:Static i18N:Keys.SettingsMultipointAuto}}"
+                    Description="{ext:Translate {x:Static i18N:Keys.SettingsMultipointAutoDescription}}"
+                    Symbol="BluetoothConnected"
+                    IsChecked="{Binding AutoEnableMultipoint, Source={x:Static config:Settings.Data}}" />
+
+                <controls:SettingsSymbolItem Content="{ext:Translate {x:Static i18N:Keys.SettingsMultipointApply}}"
+                                             Description="{ext:Translate {x:Static i18N:Keys.SettingsMultipointApplyDescription}}"
+                                             Symbol="Flash"
+                                             IsClickEnabled="True"
+                                             IsEnabled="{Binding CanApplyMultipoint}"
+                                             Click="OnApplyMultipointClicked" />
+            </ui:SettingsExpander>
+
+
             <ui:SettingsExpander Header="{ext:Translate {x:Static i18N:Keys.SettingsCrowdsourcing}}">
                 <ui:SettingsExpander.IconSource>
                     <ic:SymbolIconSource Symbol="Lightbulb" />

--- a/GalaxyBudsClient/Interface/Pages/SettingsPage.axaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/SettingsPage.axaml.cs
@@ -1,9 +1,11 @@
 using Avalonia.Interactivity;
 using FluentAvalonia.UI.Controls;
+using GalaxyBudsClient.Generated.I18N;
 using GalaxyBudsClient.Interface.Controls;
 using GalaxyBudsClient.Interface.Dialogs;
 using GalaxyBudsClient.Interface.Services;
 using GalaxyBudsClient.Interface.ViewModels.Pages;
+using GalaxyBudsClient.Platform;
 
 namespace GalaxyBudsClient.Interface.Pages;
 
@@ -33,5 +35,21 @@ public partial class SettingsPage : BasePage<SettingsPageViewModel>
     public void OnManageDevicesClicked(object? sender, RoutedEventArgs e)
     {
         NavigationService.Instance.Navigate(typeof(DevicesPageViewModel));
+    }
+
+    public async void OnApplyMultipointClicked(object? sender, RoutedEventArgs e)
+    {
+        /* The sequence disconnects and reconnects the earbuds, so keep it from being started twice */
+        if (ViewModel != null)
+            ViewModel.CanApplyMultipoint = false;
+
+        var success = await MultipointPatcher.ApplyAsync();
+        ViewModel?.RefreshMultipointState();
+
+        await new MessageBox
+        {
+            Title = Strings.SettingsMultipointHeader,
+            Description = success ? Strings.SettingsMultipointApplied : Strings.SettingsMultipointFailed
+        }.ShowAsync();
     }
 }

--- a/GalaxyBudsClient/Interface/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/GalaxyBudsClient/Interface/ViewModels/Pages/SettingsPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using Avalonia.Controls;
+using Avalonia.Threading;
 using FluentIcons.Common;
 using GalaxyBudsClient.Generated.I18N;
 using GalaxyBudsClient.Interface.Pages;
@@ -15,12 +16,23 @@ public partial class SettingsPageViewModel : MainPageViewModelBase
     {
         CanManageDevices = BluetoothImpl.HasValidDevice;
         BluetoothImpl.Instance.Device.DeviceChanged += OnDeviceChanged;
+        BluetoothImpl.Instance.Connected += (_, _) => RefreshMultipointState();
+        BluetoothImpl.Instance.Disconnected += (_, _) => RefreshMultipointState();
+        RefreshMultipointState();
     }
 
     private void OnDeviceChanged(object? sender, Device? e)
     {
         CanManageDevices = BluetoothImpl.HasValidDevice;
+        RefreshMultipointState();
     }
+
+    /* Disconnection events arrive on the Bluetooth backend's thread, so bounce back to the UI thread */
+    public void RefreshMultipointState() => Dispatcher.UIThread.Post(() =>
+    {
+        IsMultipointSupported = MultipointPatcher.IsSupportedByCurrentDevice;
+        CanApplyMultipoint = IsMultipointSupported && BluetoothImpl.Instance.IsConnected;
+    });
 
     public bool IsAutoStartEnabled
     {
@@ -33,6 +45,8 @@ public partial class SettingsPageViewModel : MainPageViewModelBase
     }
     
     [Reactive] private object _canManageDevices = false;
+    [Reactive] private bool _isMultipointSupported;
+    [Reactive] private bool _canApplyMultipoint;
     
     public string CurrentVersion => Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown";
     public override Control CreateView() => new SettingsPage { DataContext = this };

--- a/GalaxyBudsClient/Model/Config/SettingsData.cs
+++ b/GalaxyBudsClient/Model/Config/SettingsData.cs
@@ -50,6 +50,7 @@ public class SettingsData : ReactiveObject
     [ReactiveUI.Fody.Helpers.Reactive] public bool UseBluetoothWinRt { set; get; } = true;
     [ReadOnly(true)] public ObservableCollection<Device> Devices { set; get; } = [];
     [ReactiveUI.Fody.Helpers.Reactive] public string? LastDeviceMac { set; get; }
+    [ReactiveUI.Fody.Helpers.Reactive] public bool AutoEnableMultipoint { set; get; }
 
     
     /* Touch actions */

--- a/GalaxyBudsClient/Platform/MultipointPatcher.cs
+++ b/GalaxyBudsClient/Platform/MultipointPatcher.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using GalaxyBudsClient.Message;
+using GalaxyBudsClient.Model.Config;
+using GalaxyBudsClient.Model.Specifications;
+using GalaxyBudsClient.Platform.Model;
+using Serilog;
+
+namespace GalaxyBudsClient.Platform;
+
+/// <summary>
+/// Unlocks account-free multipoint coexistence on Galaxy Buds.
+///
+/// Samsung's firmware only lets a second device keep its audio link if that device's <c>asVer</c>
+/// record field is 2 or 3; anything else is force-released with reason 0xA9 as soon as the second
+/// audio connection comes up. <c>asVer</c> is written exclusively by the <c>MDE_VERSION</c> handler
+/// (opcode 0x0B) on the SMEP channel.
+///
+/// Non-Samsung hosts never send that message, which is why connecting from a PC or Mac normally
+/// kicks the phone off. The account hash carried by the same message is not part of the gate for
+/// this host (verified on hardware — a wrong hash and a zeroed hash both keep the phone connected,
+/// while asVer=0 drops it immediately), so we use the version-only form that leaves the account
+/// fields untouched.
+///
+/// The peer records holding <c>asVer</c> live in the earbuds' RAM, not in flash: booting clears
+/// every slot and writes no default, and the routine that repopulates a record when a peer connects
+/// restores the account fields from storage but reads <c>asVer</c> straight back out of the live
+/// record. So an ordinary disconnect keeps the value and a trip to the charging case loses it, and
+/// no sequence of frames makes it durable. That makes this a per-power-session write rather than a
+/// one-time patch, which is why it runs on every connection.
+/// </summary>
+public static class MultipointPatcher
+{
+    /// <summary>
+    /// MDE_VERSION SET blob, version-only variant:
+    /// <code>
+    ///   04 03 04 | 00 00 | 0B | 02
+    ///   |  |  |     |      |    `-- asVer = 2
+    ///   |  |  |     |      `------- opcode 0x0B = MDE_VERSION
+    ///   |  |  |     `-------------- reserved prefix
+    ///   |  |  `-------------------- blob length (4)
+    ///   |  `----------------------- TLV type 0x03 (blob)
+    ///   `-------------------------- TLV tag 0x04
+    /// </code>
+    /// Wrapped into WRITE_PROPERTY (0x43) inside an UNK_SPP_ALT (0x01) SMEP frame by
+    /// <see cref="SppAlternativeMessage"/>, this encodes to the exact frame captured from a Galaxy
+    /// phone and replayed successfully on hardware:
+    /// <code>FC 0B 00 01 43 04 03 04 00 00 0B 02 1E AF CC</code>
+    /// </summary>
+    private static readonly byte[] MdeVersionAsVer2 = [0x04, 0x03, 0x04, 0x00, 0x00, 0x0B, 0x02];
+
+    private const byte MdeVersionOpcode = 0x0B;
+
+    private static readonly SemaphoreSlim Lock = new(1, 1);
+
+    /// <summary>Time to wait for the SMEP channel to report itself connected.</summary>
+    private const int ConnectTimeoutMs = 10000;
+
+    /// <summary>
+    /// The earbuds' SPP4 server can take a moment to accept connections, so the first attempts
+    /// routinely fail with a generic RFCOMM error. Retrying a few times is expected, not exceptional.
+    /// </summary>
+    private const int ConnectAttempts = 4;
+
+    private const int ConnectRetryDelayMs = 1500;
+
+    /// <summary>Delay before tearing down a freshly established session for the patch sequence.</summary>
+    private const int SettleDelayMs = 3000;
+
+    /// <summary>Grace period for a backend to actually tear its stream down before reconnecting.</summary>
+    private const int DisconnectSettleMs = 500;
+
+    /// <summary>
+    /// How long to keep listening for state frames after the write. The earbuds answer within a
+    /// few hundred milliseconds, but they send a burst rather than a single frame.
+    /// </summary>
+    private const int VerifyWindowMs = 3000;
+
+    /// <summary>
+    /// Restoring the regular session raises <see cref="BluetoothImpl.Connected"/> again. Without a
+    /// window in which that echo is ignored, the hook would immediately patch itself in a loop.
+    /// It also has to expire on its own, so that a failed restore cannot mute the hook for good.
+    /// </summary>
+    private const int SelfReconnectSuppressMs = 15000;
+
+    private static DateTime _suppressUntil = DateTime.MinValue;
+
+    /// <summary>
+    /// The SMEP channel is only exposed by models that also support renaming, which is the same
+    /// set of devices this patch applies to.
+    /// </summary>
+    public static bool IsSupportedByCurrentDevice =>
+        BluetoothImpl.Instance.DeviceSpec.Supports(Features.Rename);
+
+    public static void Init()
+    {
+        BluetoothImpl.Instance.Connected += OnConnected;
+    }
+
+    private static async void OnConnected(object? sender, EventArgs e)
+    {
+        try
+        {
+            if (!Settings.Data.AutoEnableMultipoint)
+                return;
+
+            /* Our own restore reconnects, and patching that would never terminate */
+            if (DateTime.UtcNow < _suppressUntil)
+                return;
+
+            if (!IsSupportedByCurrentDevice)
+            {
+                Log.Debug("MultipointPatcher: {Model} has no SMEP channel, skipping",
+                    BluetoothImpl.Instance.CurrentModel);
+                return;
+            }
+
+            /* Let the regular session settle before tearing it down for the patch sequence */
+            await Task.Delay(SettleDelayMs);
+            if (!BluetoothImpl.Instance.IsConnected)
+                return;
+
+            await ApplyAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "MultipointPatcher: Unhandled error in the auto-patch hook");
+        }
+    }
+
+    /// <summary>
+    /// Runs the full patch sequence: drop the regular session, open the SMEP channel, write
+    /// MDE_VERSION, then restore the regular session. Safe to call while connected or disconnected.
+    /// </summary>
+    /// <returns>true if the message was written, false if any step failed.</returns>
+    public static async Task<bool> ApplyAsync()
+    {
+        if (!await Lock.WaitAsync(0))
+        {
+            Log.Warning("MultipointPatcher: A patch sequence is already running");
+            return false;
+        }
+
+        try
+        {
+            /*
+             * Connecting blocks the calling thread on some backends (macOS polls the RFCOMM channel
+             * for up to 3s inside the native call), and callers reach us from the UI thread, so the
+             * whole sequence has to run off it.
+             */
+            return await Task.Run(RunAsync);
+        }
+        finally
+        {
+            Lock.Release();
+        }
+    }
+
+    private static async Task<bool> RunAsync()
+    {
+        var bt = BluetoothImpl.Instance;
+        var wasConnected = bt.IsConnected;
+
+        try
+        {
+            Log.Information("MultipointPatcher: Writing MDE_VERSION (asVer=2) over the SMEP channel");
+
+            if (bt.IsConnected)
+            {
+                await bt.DisconnectAsync();
+                /* Backends refuse a new connection while their stream is still up */
+                await Task.Delay(DisconnectSettleMs);
+            }
+
+            if (!await Dispatcher.UIThread.InvokeAsync(() => bt.SetAltMode(true)))
+            {
+                Log.Error("MultipointPatcher: Could not switch to alt mode");
+                return false;
+            }
+
+            if (!await ConnectAltAsync())
+            {
+                Log.Error("MultipointPatcher: Could not open the SMEP channel");
+                return false;
+            }
+
+            var reported = await WriteAndReadBackAsync();
+
+            /* SendAltAsync swallows send failures, so the channel state is our only feedback */
+            if (!bt.IsConnectedAlternative)
+            {
+                Log.Error("MultipointPatcher: SMEP channel dropped while writing MDE_VERSION");
+                return false;
+            }
+
+            switch (reported)
+            {
+                case 2 or 3:
+                    Log.Information("MultipointPatcher: MDE_VERSION written and verified, asVer={AsVer}", reported);
+                    return true;
+                case { } other:
+                    Log.Error("MultipointPatcher: Wrote asVer=2, but the earbuds report {AsVer}", other);
+                    return false;
+                default:
+                    /* The write itself did not fail, so this is not an error, but nothing confirms it either */
+                    Log.Warning("MultipointPatcher: MDE_VERSION written, but the earbuds reported no state to verify it against");
+                    return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "MultipointPatcher: Failed to apply the multipoint unlock");
+            return false;
+        }
+        finally
+        {
+            await RestoreAsync(wasConnected);
+        }
+    }
+
+    /// <summary>
+    /// Writes MDE_VERSION and collects the state frames the earbuds push in response.
+    /// </summary>
+    /// <returns>the asVer the earbuds report afterwards, or null if they reported nothing.</returns>
+    private static async Task<byte?> WriteAndReadBackAsync()
+    {
+        var bt = BluetoothImpl.Instance;
+
+        /*
+         * A write is answered with a burst of state frames describing the record both before and
+         * after the change - one run that set asVer=2 reported 1, 1, 2, 2 - so the last frame is
+         * the new value and any earlier one may still be the old one.
+         */
+        byte? asVer = null;
+        void OnStateFrame(object? s, SppAlternativeMessage msg)
+        {
+            if (TryReadAsVer(msg, out var value))
+                asVer = value;
+        }
+
+        bt.MessageReceivedAlternative += OnStateFrame;
+        try
+        {
+            await SppAlternativeMessage.WritePropertyAsync(MdeVersionAsVer2);
+            await Task.Delay(VerifyWindowMs);
+        }
+        finally
+        {
+            bt.MessageReceivedAlternative -= OnStateFrame;
+        }
+
+        return asVer;
+    }
+
+    /// <summary>
+    /// Reads the stored asVer out of a state frame: a NOTIFY_PROPERTY whose payload starts with
+    /// <c>02 05 4C 0B</c> and carries the value this host is gated on at offset 6. The earbuds push
+    /// one whenever a peer record is re-evaluated, which a write reliably triggers.
+    /// </summary>
+    private static bool TryReadAsVer(SppAlternativeMessage msg, out byte asVer)
+    {
+        asVer = 0;
+
+        if (msg.Id != MsgIds.NOTIFY_PROPERTY)
+            return false;
+
+        var payload = msg.Payload;
+        if (payload.Length < 10 ||
+            payload[0] != 0x02 || payload[1] != 0x05 ||
+            payload[2] != 0x4C || payload[3] != MdeVersionOpcode)
+            return false;
+
+        asVer = payload[6];
+        return true;
+    }
+
+    private static async Task<bool> ConnectAltAsync()
+    {
+        var bt = BluetoothImpl.Instance;
+
+        for (var attempt = 1; attempt <= ConnectAttempts; attempt++)
+        {
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnAltConnected(object? s, EventArgs e) => tcs.TrySetResult(true);
+            void OnAltError(object? s, BluetoothException e) => tcs.TrySetResult(false);
+            void OnAltDisconnected(object? s, string e) => tcs.TrySetResult(false);
+
+            bt.ConnectedAlternative += OnAltConnected;
+            bt.BluetoothErrorAlternative += OnAltError;
+            bt.DisconnectedAlternative += OnAltDisconnected;
+
+            try
+            {
+                if (await bt.ConnectAsync(null, true))
+                {
+                    var winner = await Task.WhenAny(tcs.Task, Task.Delay(ConnectTimeoutMs));
+                    if (winner == tcs.Task && tcs.Task.Result)
+                        return true;
+                }
+            }
+            finally
+            {
+                bt.ConnectedAlternative -= OnAltConnected;
+                bt.BluetoothErrorAlternative -= OnAltError;
+                bt.DisconnectedAlternative -= OnAltDisconnected;
+            }
+
+            Log.Warning("MultipointPatcher: SMEP channel attempt {Attempt}/{Total} failed",
+                attempt, ConnectAttempts);
+
+            if (attempt < ConnectAttempts)
+                await Task.Delay(ConnectRetryDelayMs);
+        }
+
+        return false;
+    }
+
+    private static async Task RestoreAsync(bool reconnect)
+    {
+        var bt = BluetoothImpl.Instance;
+        try
+        {
+            if (bt.AlternativeModeEnabled)
+            {
+                await bt.DisconnectAsync(true);
+                await Task.Delay(DisconnectSettleMs);
+            }
+
+            if (!await Dispatcher.UIThread.InvokeAsync(() => bt.SetAltMode(false)))
+            {
+                Log.Error("MultipointPatcher: Stuck in alt mode, cannot restore the regular connection");
+                return;
+            }
+
+            if (reconnect)
+            {
+                _suppressUntil = DateTime.UtcNow.AddMilliseconds(SelfReconnectSuppressMs);
+                await bt.ConnectAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "MultipointPatcher: Failed to restore the regular connection");
+        }
+    }
+}

--- a/GalaxyBudsClient/i18n/en.axaml
+++ b/GalaxyBudsClient/i18n/en.axaml
@@ -462,6 +462,15 @@ Measure level: Select a vertical span to measure the battery level difference be
     <sys:String x:Key="settings_crowd_crashreport">Allow app crash reports</sys:String>
     <sys:String x:Key="settings_crowd_crashreport_description">Send application crash reports automatically in case of crashes or fatal errors using Sentry. This helps me to respond more quickly to problematic and disruptive application bugs.</sys:String>
 
+    <!--Settings >>> Multipoint-->
+    <sys:String x:Key="settings_multipoint_header">Multipoint</sys:String>
+    <sys:String x:Key="settings_multipoint_auto">Unlock multipoint without a Samsung account</sys:String>
+    <sys:String x:Key="settings_multipoint_auto_description">Your earbuds normally drop your phone as soon as a non-Samsung device connects, unless the Galaxy Wearable app is signed in. Enabling this writes the missing version marker to your earbuds every time they connect, which lets both devices stay connected. The earbuds keep the marker only until they power down, so putting them back in the case clears it.</sys:String>
+    <sys:String x:Key="settings_multipoint_apply">Apply now</sys:String>
+    <sys:String x:Key="settings_multipoint_apply_description">Write the marker again. Your earbuds will briefly disconnect and reconnect.</sys:String>
+    <sys:String x:Key="settings_multipoint_applied">Multipoint unlocked. Connect your phone to test it.</sys:String>
+    <sys:String x:Key="settings_multipoint_failed">Could not unlock multipoint. Make sure your earbuds are connected and try again.</sys:String>
+
     <!--Factory reset-->
     <sys:String x:Key="factory_header">Factory reset</sys:String>
     <sys:String x:Key="factory_confirmation">Are you sure you want to reset your earbuds to factory settings?

--- a/GalaxyBudsClient/i18n/ko.axaml
+++ b/GalaxyBudsClient/i18n/ko.axaml
@@ -382,6 +382,15 @@
     <sys:String x:Key="settings_crowd_crashreport">앱 충돌 보고서 전송 허용</sys:String>
     <sys:String x:Key="settings_crowd_crashreport_description">Sentry 서비스를 통해 앱 충돌 또는 오류 발생시 보고서를 개발자에게 자동으로 보냅니다. 이는 문제가 있거나 앱 사용에 방해가 되는 버그를 개발자가 더 빨리 수정할 수 있게 도와줍니다.</sys:String>
 
+    <!--Settings >>> Multipoint-->
+    <sys:String x:Key="settings_multipoint_header">멀티포인트</sys:String>
+    <sys:String x:Key="settings_multipoint_auto">삼성 계정 없이 멀티포인트 사용</sys:String>
+    <sys:String x:Key="settings_multipoint_auto_description">갤럭시 웨어러블 앱에 로그인하지 않으면, 삼성 기기가 아닌 장치가 연결될 때 버즈가 휴대폰과의 연결을 끊어버립니다. 이 옵션을 켜면 연결할 때마다 버즈에 누락된 버전 표시를 기록해서 두 기기가 동시에 연결된 상태를 유지할 수 있습니다. 이 표시는 버즈의 전원이 꺼질 때까지만 유지되므로, 케이스에 다시 넣으면 지워집니다.</sys:String>
+    <sys:String x:Key="settings_multipoint_apply">지금 적용</sys:String>
+    <sys:String x:Key="settings_multipoint_apply_description">버전 표시를 다시 기록합니다. 버즈가 잠시 연결 해제되었다가 다시 연결됩니다.</sys:String>
+    <sys:String x:Key="settings_multipoint_applied">멀티포인트를 활성화했어요. 휴대폰을 연결해서 확인해 보세요.</sys:String>
+    <sys:String x:Key="settings_multipoint_failed">멀티포인트를 활성화하지 못했어요. 버즈가 연결되어 있는지 확인한 뒤 다시 시도해 주세요.</sys:String>
+
     <!--Factory reset-->
     <sys:String x:Key="factory_header">버즈 초기화</sys:String>
     <sys:String x:Key="factory_confirm">버즈 초기화하기</sys:String>


### PR DESCRIPTION
Closes #529

## What this does

Galaxy Buds gate multipoint coexistence on the `MDE_VERSION` property (opcode `0x0b`) of the SMEP
service, not on a paired Samsung account. The property carries an `asVer` field, and a value of 2 or
3 opens the gate; anything else makes the firmware force-release the second audio link with reason
`0xa9` as soon as it comes up. That is why connecting from a PC or a Mac normally kicks the phone
off — a non-Samsung host never sends that message.

Writing the property from here turns the feature on without an account. The write is opt-in through a
new settings toggle, plus a button that applies it on demand.

## How it works

`MDE_VERSION` lives on SPPSERVICE4, which the client already reaches through the alternative-mode
channel used by the rename feature, so the write reuses `SppAlternativeMessage` and adds no protocol
code. A backend can only hold one RFCOMM channel at a time, so the sequence tears the regular
connection down, switches to alternative mode, writes, and restores the previous state.

The blob is the version-only variant of the message, which leaves the account fields untouched:

```
FC 0B 00 01 43 04 03 04 00 00 0B 02 1E AF CC
                        ^^ ^^ opcode 0x0B, asVer = 2
```

Nothing is assumed about the outcome. The earbuds answer a write with a burst of state frames
carrying the stored `asVer`, and the last of those is the new value — that readback is what decides
whether the run succeeded.

## The value is not durable

The peer records holding `asVer` live in the earbuds' RAM, not in flash. Booting clears every slot
and writes no default, and the routine that repopulates a record when a peer connects restores the
account fields from storage but reads `asVer` straight back out of the live record. So an ordinary
disconnect keeps the value and a trip to the charging case loses it, and no sequence of frames makes
it stick.

That makes this a per-power-session write rather than a one-time patch, which is why it runs on
connection rather than once. The bookkeeping around that is deliberately event-driven:

- A session that has been written to is not written to again. On macOS `Connected` does not only fire
  when the earbuds come back — the backend re-opens RFCOMM whenever the OS reports the device
  connecting, and duplicate events 1–2 s apart are normal. Patching each one would drop the user's
  audio for a value that is still in place.
- That flag is cleared by `Disconnected`, not by a timer. A charging-case round trip can be over in
  eight seconds, and that is exactly the moment the value has to be written again; any debounce
  measured in time would swallow it.
- A run that cannot open the SMEP channel waits a minute and gives up after three attempts on the
  same connection, since every attempt costs the user their audio link. A run that fails because the
  earbuds themselves left is not counted against that budget, so they are patched again as soon as
  they return.
- Restoring the regular session raises `Connected` again, so that echo is suppressed for a window to
  keep the hook from patching itself in a loop.

## Device scope — please read

The hook is gated on `Features.Rename`, used as a proxy for "this model exposes the SMEP channel".
That currently enables it for **nine models**: Buds Core, Buds FE, Buds2, Buds2 Pro, Buds3, Buds3 FE,
Buds3 Pro, Buds4 and Buds4 Pro.

**Only Buds2 Pro has been verified on hardware.** The reverse engineering behind this — the opcode,
the `asVer` gate, the record lifetime — was all done against Buds2 Pro firmware. The others are
included because they share the channel and the message, not because they have been tested.

If that is too wide for an initial merge, I am happy to narrow the gate to Buds2 Pro and let the
other models be enabled as people confirm them. A dedicated capability flag instead of reusing
`Features.Rename` would probably be the cleaner shape either way — guidance welcome.

## Testing

Hardware: Galaxy Buds2 Pro, macOS on Apple Silicon, Release build.

Verified:

- **First connection** — the property is written and the earbuds report it back:
  `MDE_VERSION written and verified, asVer=2`.
- **Multipoint actually works** — with `asVer=2` in place, a phone and the Mac hold their audio links
  at the same time instead of the phone being released with reason `0xa9`. No Samsung account
  involved on either side.
- **One write per power session** — 11 minutes connected and idle after the first write produced no
  further writes.
- **Duplicate connect events** — two `Connected` events 1.6 s apart produced a single write.
- **Charging-case round trip** — buds into the case and back out inside ~10 s; the value is written
  again and confirmed, `asVer=2`.
- The frame was cross-checked against an independent host-side decoder, which parses the same
  `NOTIFY_PROPERTY` state frame identically.

Not verified:

- **Windows and Linux.** Both build, but neither has been run against hardware. The sequence itself
  is backend-agnostic, but the connect/disconnect timing constants were tuned on the macOS backend
  and may want different values elsewhere.
- **The other eight models**, as above.
- **Behaviour when a Samsung account is already paired.** The version-only blob leaves the account
  fields untouched by design, but this was only exercised on an account-free setup.
- Long-lived idle sessions on the order of hours.

## Notes for reviewers

- The sequence briefly drops the audio link (~8 s) once per earbud power session. That is inherent to
  needing the RFCOMM channel for the write; the toggle is off by default so nobody pays for it
  without asking.
- Timing constants (settle delay, connect retries, verify window) are all named constants at the top
  of `MultipointPatcher.cs`, so they are easy to adjust per backend if that turns out to be needed.
- Strings are added to `en.axaml` and `ko.axaml`; the remaining locales fall back to English.